### PR TITLE
[Feature] Issue – 도메인 모델 정의 및 목록 조회/필터링 API 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-aop'
+	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/main/java/elbin_bank/issue_tracker/common/aop/AuditingAspect.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/common/aop/AuditingAspect.java
@@ -1,0 +1,27 @@
+package elbin_bank.issue_tracker.common.aop;
+
+import elbin_bank.issue_tracker.common.domain.BaseEntity;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Aspect
+@Component
+public class AuditingAspect {
+
+    @Before("execution(* org.springframework.data.repository.CrudRepository+.save(..))")
+    public void touchDates(JoinPoint jp) {
+        Object arg = jp.getArgs()[0];
+        if (arg instanceof BaseEntity entity) {
+            LocalDateTime now = LocalDateTime.now();
+            if (entity.getCreatedAt() == null) {
+                entity.setCreatedAt(now);
+            }
+            entity.setUpdatedAt(now);
+        }
+    }
+
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/common/config/AopConfig.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/common/config/AopConfig.java
@@ -1,0 +1,9 @@
+package elbin_bank.issue_tracker.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+@Configuration
+@EnableAspectJAutoProxy
+public class AopConfig {
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/common/config/WebConfig.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/common/config/WebConfig.java
@@ -1,0 +1,18 @@
+package elbin_bank.issue_tracker.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins("http://localhost:5173")
+                .allowedMethods("*")
+                .allowCredentials(true);
+    }
+
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/common/domain/BaseEntity.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/common/domain/BaseEntity.java
@@ -2,6 +2,7 @@ package elbin_bank.issue_tracker.common.domain;
 
 
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.relational.core.mapping.Column;
@@ -9,6 +10,7 @@ import org.springframework.data.relational.core.mapping.Column;
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
 public abstract class BaseEntity {
 
     @Column("created_at")

--- a/backend/src/main/java/elbin_bank/issue_tracker/common/domain/BaseEntity.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/common/domain/BaseEntity.java
@@ -1,0 +1,29 @@
+package elbin_bank.issue_tracker.common.domain;
+
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.relational.core.mapping.Column;
+
+import java.time.LocalDateTime;
+
+@Getter
+public abstract class BaseEntity {
+
+    @Column("created_at")
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Column("updated_at")
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @Column("deleted_at")
+    private LocalDateTime deletedAt;
+
+    public void markDeleted(LocalDateTime when) {
+        this.deletedAt = when;
+    }
+
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/issue/application/query/FilterConditionParser.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/issue/application/query/FilterConditionParser.java
@@ -1,0 +1,25 @@
+package elbin_bank.issue_tracker.issue.application.query;
+
+public class FilterConditionParser {
+
+    public static FilterCriteria parse(String q) {
+        Boolean isClosed = null;
+
+        if (q != null && !q.isBlank()) {
+            String[] parts = q.split(" ");
+
+            for (String p : parts) {
+                if (p.startsWith("state:")) {
+                    boolean open = p.equals("state:open");
+                    boolean close = p.equals("state:closed");
+                    if (open && close) {
+                        throw new IllegalStateException("Filter conditions cannot be open or open closed");
+                    }
+                    isClosed = close;
+                }
+            }
+        }
+        return new FilterCriteria(isClosed);
+    }
+
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/issue/application/query/FilterConditionParser.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/issue/application/query/FilterConditionParser.java
@@ -3,22 +3,29 @@ package elbin_bank.issue_tracker.issue.application.query;
 public class FilterConditionParser {
 
     public static FilterCriteria parse(String q) {
-        Boolean isClosed = null;
+        boolean isClosed = false;
+        boolean open = false;
+        boolean closed = false;
 
         if (q != null && !q.isBlank()) {
             String[] parts = q.split(" ");
 
             for (String p : parts) {
                 if (p.startsWith("state:")) {
-                    boolean open = p.equals("state:open");
-                    boolean close = p.equals("state:closed");
-                    if (open && close) {
-                        throw new IllegalStateException("Filter conditions cannot be open or open closed");
+                    if (p.equals("state:closed")) {
+                        closed = true;
                     }
-                    isClosed = close;
+                    if (p.equals("state:open")) {
+                        open = true;
+                    }
                 }
             }
+            if (open && closed) {
+                throw new IllegalStateException("Filter conditions cannot be open or open closed");
+            }
+            isClosed = closed;
         }
+
         return new FilterCriteria(isClosed);
     }
 

--- a/backend/src/main/java/elbin_bank/issue_tracker/issue/application/query/FilterCriteria.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/issue/application/query/FilterCriteria.java
@@ -1,0 +1,6 @@
+package elbin_bank.issue_tracker.issue.application.query;
+
+public record FilterCriteria(
+        Boolean isClosed
+) {
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/issue/application/query/GetFilteredIssueListService.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/issue/application/query/GetFilteredIssueListService.java
@@ -1,0 +1,73 @@
+package elbin_bank.issue_tracker.issue.application.query;
+
+import elbin_bank.issue_tracker.issue.application.query.dto.IssueSummaryDto;
+import elbin_bank.issue_tracker.issue.application.query.dto.IssuesResponseDto;
+import elbin_bank.issue_tracker.issue.domain.Issue;
+import elbin_bank.issue_tracker.issue.domain.IssueRepository;
+import elbin_bank.issue_tracker.issue.domain.IssueStatus;
+import elbin_bank.issue_tracker.label.application.query.dto.LabelsDto;
+import elbin_bank.issue_tracker.label.domain.Label;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyList;
+
+@Service
+public class GetFilteredIssueListService {
+
+    private final IssueRepository issueRepository;
+
+    public GetFilteredIssueListService(IssueRepository issueRepository) {
+        this.issueRepository = issueRepository;
+    }
+
+    private static final Map<Long, String> userNames = Map.of(
+            0L, "elbin",
+            1L, "glad",
+            2L, "wanja",
+            3L, "wanja",
+            4L, "gd"
+    );
+
+    @Transactional(readOnly = true)
+    public IssuesResponseDto find(String q) {
+        FilterCriteria crit = FilterConditionParser.parse(q);
+        List<Issue> issues = issueRepository.findByFilter(crit.isClosed());
+        if (issues.isEmpty()) {
+            return new IssuesResponseDto(List.of(), 0L, 0L);
+        }
+
+        List<Long> issueIds = issues.stream().map(Issue::getId).toList();
+        List<Long> authorIds = issues.stream().map(Issue::getAuthorId).distinct().toList();
+
+//        Map<Long, String> authors = userRepo.findNicknamesByIds(authorIds); @todo
+        Map<Long, List<Label>> labelsMap = issueRepository.findLabelsByIssueIds(issueIds);
+        Map<Long, List<String>> assigneesMap = issueRepository.findAssigneesByIssueIds(issueIds);
+
+        List<IssueSummaryDto> dtos = issues.stream().map(i ->
+                        new IssueSummaryDto(
+                                i.getId(),
+//                        authors.get(i.getAuthorId()), @todo
+                                userNames.get(i.getAuthorId()),
+                                i.getTitle(),
+                                labelsMap.getOrDefault(i.getId(), emptyList())
+                                        .stream().map(label -> new LabelsDto(label.getId(), label.getName(), label.getDescription(), label.getColor())
+                                        ).toList(),
+                                i.isClosed(),
+                                i.getCreatedAt(),
+                                i.getUpdatedAt(),
+                                assigneesMap.getOrDefault(i.getId(), emptyList()),
+                                "hello wanja" // @todo
+                        )
+        ).toList();
+
+        long openCount = issueRepository.countByStatus(IssueStatus.OPEN);
+        long closeCount = issueRepository.countByStatus(IssueStatus.CLOSED);
+
+        return new IssuesResponseDto(dtos, openCount, closeCount);
+    }
+
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/issue/application/query/dto/IssueSummaryDto.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/issue/application/query/dto/IssueSummaryDto.java
@@ -1,0 +1,19 @@
+package elbin_bank.issue_tracker.issue.application.query.dto;
+
+import elbin_bank.issue_tracker.label.application.query.dto.LabelsDto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record IssueSummaryDto(
+        Long id,
+        String author,
+        String title,
+        List<LabelsDto> labels,
+        boolean isClosed,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        List<String> assigneesProfileImages,
+        String milestone
+) {
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/issue/application/query/dto/IssuesResponseDto.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/issue/application/query/dto/IssuesResponseDto.java
@@ -1,0 +1,6 @@
+package elbin_bank.issue_tracker.issue.application.query.dto;
+
+import java.util.List;
+
+public record IssuesResponseDto(List<IssueSummaryDto> issues, long openCount, long closeCount) {
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/issue/domain/Issue.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/issue/domain/Issue.java
@@ -4,6 +4,7 @@ import elbin_bank.issue_tracker.common.domain.BaseEntity;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
@@ -12,6 +13,7 @@ import org.springframework.data.relational.core.mapping.Table;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
+@Setter
 public class Issue extends BaseEntity {
 
     @Id

--- a/backend/src/main/java/elbin_bank/issue_tracker/issue/domain/Issue.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/issue/domain/Issue.java
@@ -34,4 +34,8 @@ public class Issue extends BaseEntity {
     @Column("file_path")
     private String filePath;
 
+    public boolean isClosed() {
+        return Boolean.TRUE.equals(isClosed);
+    }
+
 }

--- a/backend/src/main/java/elbin_bank/issue_tracker/issue/domain/Issue.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/issue/domain/Issue.java
@@ -1,0 +1,37 @@
+package elbin_bank.issue_tracker.issue.domain;
+
+import elbin_bank.issue_tracker.common.domain.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table("issue")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class Issue extends BaseEntity {
+
+    @Id
+    private Long id;
+
+    @Column("writer_id")
+    private Long authorId;
+
+    @Column("milestone_id")
+    private Long milestoneId;
+
+    private String title;
+
+    @Column("contents")
+    private String contents;
+
+    @Column("is_closed")
+    private Boolean isClosed;
+
+    @Column("file_path")
+    private String filePath;
+
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/issue/domain/IssueRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/issue/domain/IssueRepository.java
@@ -1,10 +1,8 @@
 package elbin_bank.issue_tracker.issue.domain;
 
-import org.springframework.data.repository.CrudRepository;
-
 import java.util.List;
 
-public interface IssueRepository extends CrudRepository<Issue, Long> {
+public interface IssueRepository {
 
     List<Issue> findByFilter(Boolean isClosed);
 

--- a/backend/src/main/java/elbin_bank/issue_tracker/issue/domain/IssueRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/issue/domain/IssueRepository.java
@@ -1,0 +1,13 @@
+package elbin_bank.issue_tracker.issue.domain;
+
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+
+public interface IssueRepository extends CrudRepository<Issue, Long> {
+
+    List<Issue> findByFilter(Boolean isClosed);
+
+    long countByStatus(IssueStatus status);
+
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/issue/domain/IssueRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/issue/domain/IssueRepository.java
@@ -1,11 +1,18 @@
 package elbin_bank.issue_tracker.issue.domain;
 
+import elbin_bank.issue_tracker.label.domain.Label;
+
 import java.util.List;
+import java.util.Map;
 
 public interface IssueRepository {
 
     List<Issue> findByFilter(Boolean isClosed);
 
     long countByStatus(IssueStatus status);
+
+    Map<Long, List<Label>> findLabelsByIssueIds(List<Long> issueIds);
+
+    Map<Long, List<String>> findAssigneesByIssueIds(List<Long> issueIds);
 
 }

--- a/backend/src/main/java/elbin_bank/issue_tracker/issue/domain/IssueStatus.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/issue/domain/IssueStatus.java
@@ -1,0 +1,5 @@
+package elbin_bank.issue_tracker.issue.domain;
+
+public enum IssueStatus {
+    OPEN, CLOSED
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/issue/infrastructure/IssueQueryBuilder.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/issue/infrastructure/IssueQueryBuilder.java
@@ -1,0 +1,39 @@
+package elbin_bank.issue_tracker.issue.infrastructure;
+
+import lombok.Getter;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class IssueQueryBuilder {
+
+    private final StringBuilder sql;
+    @Getter
+    private final MapSqlParameterSource params;
+    private final List<String> where;
+
+    public IssueQueryBuilder() {
+        this.sql = new StringBuilder("SELECT DISTINCT i.* FROM Issue i");
+        this.params = new MapSqlParameterSource();
+        this.where = new ArrayList<>();
+    }
+
+    public IssueQueryBuilder filterClosed(Boolean isClosed) {
+        if (isClosed != null) {
+            where.add("i.is_closed = :isClosed");
+            params.addValue("isClosed", isClosed);
+        }
+
+        return this;
+    }
+
+    public String buildSql() {
+        if (!where.isEmpty()) {
+            sql.append(" WHERE ").append(String.join(" AND ", where));
+        }
+
+        return sql.toString();
+    }
+
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/issue/infrastructure/JdbcIssueRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/issue/infrastructure/JdbcIssueRepository.java
@@ -3,12 +3,16 @@ package elbin_bank.issue_tracker.issue.infrastructure;
 import elbin_bank.issue_tracker.issue.domain.Issue;
 import elbin_bank.issue_tracker.issue.domain.IssueRepository;
 import elbin_bank.issue_tracker.issue.domain.IssueStatus;
+import elbin_bank.issue_tracker.label.domain.Label;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
+import java.util.AbstractMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Repository
 public class JdbcIssueRepository implements IssueRepository {
@@ -23,25 +27,92 @@ public class JdbcIssueRepository implements IssueRepository {
     public List<Issue> findByFilter(Boolean isClosed) {
         IssueQueryBuilder builder = new IssueQueryBuilder()
                 .filterClosed(isClosed);
-        String sql = builder.buildSql();
-
-        return jdbc.query(sql, builder.getParams(),
-                BeanPropertyRowMapper.newInstance(Issue.class));
+        return jdbc.query(
+                builder.buildSql(),
+                builder.getParams(),
+                BeanPropertyRowMapper.newInstance(Issue.class)
+        );
     }
 
     @Override
     public long countByStatus(IssueStatus status) {
         String sql = "SELECT COUNT(*) FROM Issue WHERE is_closed = :st";
-        Long count = jdbc.queryForObject(sql,
+        Long count = jdbc.queryForObject(
+                sql,
                 new MapSqlParameterSource("st", status == IssueStatus.CLOSED),
                 Long.class
         );
 
         if (count == null) {
-            return 0;
+            return 0L;
         }
 
         return count;
     }
 
+    @Override
+    public Map<Long, List<Label>> findLabelsByIssueIds(List<Long> issueIds) {
+        if (issueIds == null || issueIds.isEmpty()) {
+            return Map.of();
+        }
+        String sql = """
+                SELECT il.issue_id      AS issueId,
+                       l.id             AS id,
+                       l.name           AS name,
+                       l.color          AS color,
+                       l.description    AS description
+                  FROM issue_label il
+                  JOIN Label l ON l.id = il.label_id
+                 WHERE il.issue_id IN (:ids)
+                """;
+        var params = new MapSqlParameterSource("ids", issueIds);
+
+        List<AbstractMap.SimpleEntry<Long, Label>> rows = jdbc.query(
+                sql, params,
+                (rs, rn) -> new AbstractMap.SimpleEntry<>(
+                        rs.getLong("issueId"),
+                        new Label(
+                                rs.getLong("id"),
+                                rs.getString("name"),
+                                rs.getString("color"),
+                                rs.getString("description")
+                        )
+                )
+        );
+
+        return rows.stream()
+                .collect(Collectors.groupingBy(
+                        AbstractMap.SimpleEntry::getKey,
+                        Collectors.mapping(AbstractMap.SimpleEntry::getValue, Collectors.toList())
+                ));
+    }
+
+    @Override
+    public Map<Long, List<String>> findAssigneesByIssueIds(List<Long> issueIds) {
+        if (issueIds == null || issueIds.isEmpty()) {
+            return Map.of();
+        }
+        String sql = """
+                SELECT a.issue_id          AS issueId,
+                       u.profile_image_url AS imageUrl
+                  FROM Assignee a
+                  JOIN User u ON u.id = a.user_id
+                 WHERE a.issue_id IN (:ids)
+                """;
+        var params = new MapSqlParameterSource("ids", issueIds);
+
+        List<AbstractMap.SimpleEntry<Long, String>> rows = jdbc.query(
+                sql, params,
+                (rs, rn) -> new AbstractMap.SimpleEntry<>(
+                        rs.getLong("issueId"),
+                        rs.getString("imageUrl")
+                )
+        );
+
+        return rows.stream()
+                .collect(Collectors.groupingBy(
+                        AbstractMap.SimpleEntry::getKey,
+                        Collectors.mapping(AbstractMap.SimpleEntry::getValue, Collectors.toList())
+                ));
+    }
 }

--- a/backend/src/main/java/elbin_bank/issue_tracker/issue/infrastructure/JdbcIssueRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/issue/infrastructure/JdbcIssueRepository.java
@@ -1,0 +1,47 @@
+package elbin_bank.issue_tracker.issue.infrastructure;
+
+import elbin_bank.issue_tracker.issue.domain.Issue;
+import elbin_bank.issue_tracker.issue.domain.IssueRepository;
+import elbin_bank.issue_tracker.issue.domain.IssueStatus;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class JdbcIssueRepository implements IssueRepository {
+
+    private final NamedParameterJdbcTemplate jdbc;
+
+    public JdbcIssueRepository(NamedParameterJdbcTemplate jdbc) {
+        this.jdbc = jdbc;
+    }
+
+    @Override
+    public List<Issue> findByFilter(Boolean isClosed) {
+        IssueQueryBuilder builder = new IssueQueryBuilder()
+                .filterClosed(isClosed);
+        String sql = builder.buildSql();
+
+        return jdbc.query(sql, builder.getParams(),
+                BeanPropertyRowMapper.newInstance(Issue.class));
+    }
+
+    @Override
+    public long countByStatus(IssueStatus status) {
+        String sql = "SELECT COUNT(*) FROM Issue WHERE is_closed = :st";
+        Long count = jdbc.queryForObject(sql,
+                new MapSqlParameterSource("st", status == IssueStatus.CLOSED),
+                Long.class
+        );
+
+        if (count == null) {
+            return 0;
+        }
+
+        return count;
+    }
+
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/issue/presentation/IssueQueryController.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/issue/presentation/IssueQueryController.java
@@ -1,0 +1,24 @@
+package elbin_bank.issue_tracker.issue.presentation;
+
+import elbin_bank.issue_tracker.issue.application.query.GetFilteredIssueListService;
+import elbin_bank.issue_tracker.issue.application.query.dto.IssuesResponseDto;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/issues")
+public class IssueQueryController {
+    private final GetFilteredIssueListService getFilteredIssueListService;
+
+    public IssueQueryController(GetFilteredIssueListService getFilteredIssueListService) {
+        this.getFilteredIssueListService = getFilteredIssueListService;
+    }
+
+    @GetMapping("")
+    public IssuesResponseDto list(@RequestParam(value = "q", required = false) String q) {
+        return getFilteredIssueListService.find(q);
+    }
+
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/issue/presentation/IssueQueryController.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/issue/presentation/IssueQueryController.java
@@ -2,6 +2,7 @@ package elbin_bank.issue_tracker.issue.presentation;
 
 import elbin_bank.issue_tracker.issue.application.query.GetFilteredIssueListService;
 import elbin_bank.issue_tracker.issue.application.query.dto.IssuesResponseDto;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -17,8 +18,12 @@ public class IssueQueryController {
     }
 
     @GetMapping("")
-    public IssuesResponseDto list(@RequestParam(value = "q", required = false) String q) {
-        return getFilteredIssueListService.find(q);
+    public ResponseEntity<IssuesResponseDto> list(@RequestParam(value = "q", required = false) String q) {
+        try {
+            return ResponseEntity.ok(getFilteredIssueListService.find(q));
+        } catch (IllegalStateException e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 
 }

--- a/backend/src/main/java/elbin_bank/issue_tracker/label/application/query/dto/LabelsDto.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/label/application/query/dto/LabelsDto.java
@@ -1,0 +1,7 @@
+package elbin_bank.issue_tracker.label.application.query.dto;
+
+public record LabelsDto(Long id,
+                        String name,
+                        String color,
+                        String description) {
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/label/domain/Label.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/label/domain/Label.java
@@ -1,0 +1,29 @@
+package elbin_bank.issue_tracker.label.domain;
+
+import elbin_bank.issue_tracker.common.domain.BaseEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table("label")
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class Label extends BaseEntity {
+
+    @Id
+    private Long id;
+
+    @Column("name")
+    private String name;
+
+    @Column("description")
+    private String description;
+
+    @Column("color")
+    private String color;
+
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,8 @@
+spring.config.import=optional:file:.env
+
+spring.sql.init.mode=always
 spring.application.name=issue-tracker
+spring.datasource.url=${MYSQL_DATABASE_URL}
+spring.datasource.username=${MYSQL_DATABASE_USERNAME}
+spring.datasource.password=${MYSQL_DATABASE_PASSWORD}
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,0 +1,41 @@
+-- ▶ user 테이블
+INSERT INTO `user` (`github_id`, `login`, `password`, `nickname`, `profile_image_url`, `uuid`, `created_at`)
+VALUES (1001, 'alice', 'passAlice', 'Alice', 'https://example.com/alice.png', 'uuid-alice', NOW()),
+       (1002, 'bob', 'passBob', 'Bob', 'https://example.com/bob.png', 'uuid-bob', NOW()),
+       (1003, 'carol', 'passCarol', 'Carol', 'https://example.com/carol.png', 'uuid-carol', NOW());
+
+-- ▶ milestone 테이블
+INSERT INTO `milestone` (`is_closed`, `title`, `description`, `expired_at`, `created_at`)
+VALUES (FALSE, 'Release v1.0', '첫 번째 릴리즈 마일스톤', '2025-06-01', NOW()),
+       (TRUE, 'Hotfix', '긴급 버그 수정', '2025-05-20', NOW()),
+       (FALSE, 'v2 Planning', '2.0 기획 단계', NULL, NOW());
+
+-- ▶ label 테이블
+INSERT INTO `label` (`name`, `description`, `color`, `created_at`)
+VALUES ('bug', '버그 관련', '#d73a4a', NOW()),
+       ('enhancement', '기능 개선', '#a2eeef', NOW()),
+       ('question', '문의 및 질문', '#d876e3', NOW());
+
+-- ▶ issue 테이블
+INSERT INTO `issue` (`author_id`, `milestone_id`, `title`, `contents`, `is_closed`, `file_path`, `created_at`)
+VALUES (1, 1, '로그인 오류', '소셜 로그인 시 500 에러 발생', FALSE, NULL, NOW()),
+       (2, NULL, 'UI 개선 요청', '메인 페이지 배너 위치 조정', FALSE, NULL, NOW()),
+       (3, 2, '치명적 버그', '데이터베이스 연결 실패', TRUE, NULL, NOW());
+
+-- ▶ comment 테이블
+INSERT INTO `comment` (`label_id`, `user_id`, `contents`, `file_path`, `created_at`)
+VALUES (1, 2, '저도 같은 오류가 재현됩니다', NULL, NOW()),
+       (3, 1, '이 부분 어떻게 동작하나요?', NULL, NOW()),
+       (2, 3, '이슈와 연관된 PR이 준비되었습니다', NULL, NOW());
+
+-- ▶ assignee 테이블
+INSERT INTO `assignee` (`user_id`, `issue_id`)
+VALUES (2, 1),
+       (3, 1),
+       (1, 2);
+
+-- ▶ issue_label 테이블
+INSERT INTO `issue_label` (`issue_id`, `label_id`)
+VALUES (1, 1),
+       (1, 3),
+       (2, 2);

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -1,0 +1,93 @@
+DROP TABLE IF EXISTS `issue_label`;
+DROP TABLE IF EXISTS `assignee`;
+DROP TABLE IF EXISTS `comment`;
+DROP TABLE IF EXISTS `issue`;
+DROP TABLE IF EXISTS `label`;
+DROP TABLE IF EXISTS `milestone`;
+DROP TABLE IF EXISTS `user`;
+
+CREATE TABLE `user`
+(
+    `id`                BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `github_id`         BIGINT UNSIGNED NULL,
+    `login`             VARCHAR(255) NULL,
+    `password`          VARCHAR(255) NULL,
+    `nickname`          VARCHAR(255) NOT NULL,
+    `profile_image_url` VARCHAR(255) NULL,
+    `uuid`              VARCHAR(255) NOT NULL,
+    `created_at`        DATETIME     NOT NULL,
+    `updated_at`        DATETIME NULL,
+    `deleted_at`        DATETIME NULL,
+    UNIQUE KEY `user_uuid_unique` (`uuid`)
+);
+
+CREATE TABLE `milestone`
+(
+    `id`          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `is_closed`   BOOLEAN      NOT NULL,
+    `title`       VARCHAR(255) NOT NULL,
+    `description` TEXT NULL,
+    `expired_at`  DATE NULL,
+    `created_at`  DATETIME     NOT NULL,
+    `updated_at`  DATETIME NULL,
+    `deleted_at`  DATETIME NULL
+);
+
+CREATE TABLE `issue`
+(
+    `id`           BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `author_id`    BIGINT UNSIGNED NOT NULL,
+    `milestone_id` BIGINT UNSIGNED NULL,
+    `title`        VARCHAR(255) NOT NULL,
+    `contents`     TEXT         NOT NULL,
+    `is_closed`    BOOLEAN      NOT NULL,
+    `file_path`    VARCHAR(255) NULL,
+    `created_at`   DATETIME     NOT NULL,
+    `updated_at`   DATETIME NULL,
+    `deleted_at`   DATETIME NULL,
+    FOREIGN KEY (`author_id`) REFERENCES `user` (`id`),
+    FOREIGN KEY (`milestone_id`) REFERENCES `milestone` (`id`)
+);
+
+CREATE TABLE `label`
+(
+    `id`          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `name`        VARCHAR(255) NOT NULL,
+    `description` VARCHAR(255) NULL,
+    `color`       VARCHAR(255) NOT NULL,
+    `created_at`  DATETIME     NOT NULL,
+    `updated_at`  DATETIME NULL,
+    `deleted_at`  DATETIME NULL
+);
+
+CREATE TABLE `comment`
+(
+    `id`         BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `label_id`   BIGINT UNSIGNED NULL,
+    `user_id`    BIGINT UNSIGNED NOT NULL,
+    `contents`   TEXT     NOT NULL,
+    `file_path`  VARCHAR(255) NULL,
+    `created_at` DATETIME NOT NULL,
+    `updated_at` DATETIME NULL,
+    `deleted_at` DATETIME NULL,
+    FOREIGN KEY (`user_id`) REFERENCES `user` (`id`),
+    FOREIGN KEY (`label_id`) REFERENCES `label` (`id`)
+);
+
+CREATE TABLE `assignee`
+(
+    `id`       BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `user_id`  BIGINT UNSIGNED NOT NULL,
+    `issue_id` BIGINT UNSIGNED NOT NULL,
+    FOREIGN KEY (`user_id`) REFERENCES `user` (`id`),
+    FOREIGN KEY (`issue_id`) REFERENCES `issue` (`id`)
+);
+
+CREATE TABLE `issue_label`
+(
+    `id`       BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    `issue_id` BIGINT UNSIGNED NOT NULL,
+    `label_id` BIGINT UNSIGNED NOT NULL,
+    FOREIGN KEY (`issue_id`) REFERENCES `issue` (`id`),
+    FOREIGN KEY (`label_id`) REFERENCES `label` (`id`)
+);


### PR DESCRIPTION
## **✅ 작업 요약**

- Issue 도메인 엔티티 (Issue, IssueStatus) 및 Spring Data JDBC 리포지토리 구현
- IssueQueryBuilder를 통한 동적 SQL 빌더 추가
- GET /api/v1/issues 엔드포인트 구현
    - 전체 목록 조회
    - 쿼리스트링 q=state:open/q=state:close를 통한 열린·닫힌 이슈 필터링
- 응답 DTO 작성 (IssuesResponseDto, IssueSummaryDto, LabelDto)
- FilterConditionParser로 필터 파라미터 파싱 로직 분리
- BeanPropertyRowMapper 및 커스텀 매퍼를 활용해 다대다 관계(레이블, 어싸이니) 처리

## **✅ 테스트 확인**

- 등록된 이슈 조건으로 open, closed 필터링 기능 확인

## **🧠 회고/고민**

- DDD 중에서 CQRS 패턴을 활용해서 구현을 해보았으나 잘 구현했는지 잘 모르겠음
- FilterConditionParser 설계 시 다양한 필터 확장(레이블, 어싸이니 등) 추후 확작성 고려해서 작성함
- BeanPropertyRowMapper 매핑을 위해 엔티티에 setter 추가 필요성 인식
- 동적 SQL 빌더 구현 시 가독성과 재사용성 균형 맞추기

## **🔗 참고 자료**
