### PR TITLE
[Bug] fe 폴더 내부에 배포용 환경 변수 파일 추가

### DIFF
--- a/fe/.env.production
+++ b/fe/.env.production
@@ -1,0 +1,1 @@
+VITE_API_HOST=http://localhost:8080 


### PR DESCRIPTION
## 📌 PR 제목  
fe 폴더 내부에 배포용 환경 변수 파일 추가


## ✅ 작업 요약

- `.env.production` 파일을 `fe/` 디렉토리에 추가  
- Vite 빌드 시 환경변수가 `undefined`로 치환되는 문제 해결  
- 배포 환경에서 API 요청 실패(403, undefined 경로 등) 방지


## ✅ 테스트 확인

- [x] `vite build` 결과에 환경변수 값이 포함됨 (`dist` 내 확인)
- [x] `vite preview`로 실행 시 API 요청 정상 작동 확인
- [x] 브라우저 콘솔 및 네트워크 탭에서 URL 이상 없음 확인


## 🧠 회고/고민

- 개발 환경에서는 `.env.development`만으로 충분했으나,  
  배포 환경에서는 `.env.production`이 없을 경우 API 연결이 실패하는 상황이 발생  
- 환경별 `.env` 파일 관리의 중요성을 다시 확인함

closes #25 