### PR TITLE
[Feature] 메인화면 툴바 버튼 라우팅 기능 구현

### DIFF
--- a/fe/src/features/issue/components/CreateIssueButton.tsx
+++ b/fe/src/features/issue/components/CreateIssueButton.tsx
@@ -1,0 +1,37 @@
+import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
+import PlusIcon from '@/assets/icons/plus.svg?react';
+
+export default function CreateIssueButton() {
+  const navigate = useNavigate();
+
+  return (
+    <StyledButton onClick={() => navigate('/issues/new')}>
+      <PlusIcon />
+      <StyledLabel>이슈 작성</StyledLabel>
+    </StyledButton>
+  );
+}
+
+const StyledButton = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 128px;
+  padding: 12px 0;
+  background-color: ${({ theme }) => theme.palette.blue};
+  border-radius: ${({ theme }) => theme.radius.medium};
+  color: #ffffff;
+
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    opacity: 0.8;
+  }
+`;
+
+const StyledLabel = styled.span`
+  padding: 0 4px;
+  ${({ theme }) => theme.typography.availableMedium12};
+`;

--- a/fe/src/features/issue/components/list/IssueAdvancedFilter.tsx
+++ b/fe/src/features/issue/components/list/IssueAdvancedFilter.tsx
@@ -1,3 +1,96 @@
-export default function IssueAdvancedFilter() {
-  return <div>IssueAdvancedFilter</div>;
+import styled from '@emotion/styled';
+import ChevronDownIcon from '@/assets/icons/chevronDown.svg?react';
+import SearchIcon from '@/assets/icons/search.svg?react';
+
+interface IssueAdvancedFilterProps {
+  searchValue: string;
+  onSearchChange: (value: string) => void;
+  placeholder?: string;
 }
+
+export default function IssueAdvancedFilter({
+  searchValue,
+  onSearchChange,
+  placeholder = 'placeholder',
+}: IssueAdvancedFilterProps) {
+  return (
+    <FilterWrapper>
+      <FilterButton type="button">
+        <DropdownIndicator label="필터" />
+      </FilterButton>
+
+      <SearchArea>
+        <SearchIcon width={16} height={16} />
+        <SearchInput
+          value={searchValue}
+          onChange={e => onSearchChange(e.target.value)}
+          placeholder={placeholder}
+        />
+      </SearchArea>
+    </FilterWrapper>
+  );
+}
+
+const FilterWrapper = styled.div`
+  width: 560px;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  border-radius: ${({ theme }) => theme.radius.medium};
+  border: 1px solid ${({ theme }) => theme.borderColor.default};
+`;
+
+const FilterButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 24px;
+  border: none;
+  background-color: ${({ theme }) => theme.surfaceColor.default};
+  color: ${({ theme }) => theme.textColor.default};
+  ${({ theme }) => theme.typography.availableMedium16};
+  cursor: pointer;
+`;
+
+const SearchArea = styled.label`
+  display: flex;
+  align-items: center;
+  flex: 1;
+  gap: 8px;
+  padding: 8px 24px;
+  height: 100%;
+  border-left: 1px solid ${({ theme }) => theme.borderColor.default};
+  background-color: ${({ theme }) => theme.surfaceColor.bold};
+  color: ${({ theme }) => theme.textColor.default};
+`;
+
+const SearchInput = styled.input`
+  all: unset;
+  flex: 1;
+  color: ${({ theme }) => theme.textColor.weak};
+  ${({ theme }) => theme.typography.availableMedium16};
+`;
+
+//TODO 공통 컴포넌트로 분리
+function DropdownIndicator({ label }: { label: string }) {
+  return (
+    <IndicatorWrapper>
+      <IndicatorLabel>{label}</IndicatorLabel>
+      <ChevronDownIcon width={16} height={16} />
+    </IndicatorWrapper>
+  );
+}
+
+const IndicatorWrapper = styled.div`
+  width: 80px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+`;
+
+const IndicatorLabel = styled.span`
+  padding: 4px 0;
+  white-space: nowrap;
+  ${({ theme }) => theme.typography.availableMedium16};
+`;

--- a/fe/src/layouts/VerticalStack.tsx
+++ b/fe/src/layouts/VerticalStack.tsx
@@ -1,0 +1,9 @@
+import styled from '@emotion/styled';
+
+const VerticalStack = styled.div<{ gap?: number; padding?: number }>`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ gap = 24 }) => gap}px;
+`;
+
+export default VerticalStack;

--- a/fe/src/pages/IssueListPage.tsx
+++ b/fe/src/pages/IssueListPage.tsx
@@ -1,17 +1,50 @@
 import { useState } from 'react';
+import styled from '@emotion/styled';
 import { type IssueStatus } from '@/features/issue/types/issue';
+import VerticalStack from '@/layouts/VerticalStack';
+import IssueAdvancedFilter from '@/features/issue/components/list/IssueAdvancedFilter';
 import IssueListContainer from '@/features/issue/components/list/IssueListContainer';
+import LabelMilestoneTab from '@/shared/components/LabelMilestoneTab';
+import CreateIssueButton from '@/features/issue/components/CreateIssueButton';
 
 export default function IssueListPage() {
   const [selectedTab, setSelectedTab] = useState<IssueStatus>('open');
+  const [queryOptions, setQueryOptions] = useState('is:issue is:open');
+
+  const handleSearchChange = (value: string) => {
+    setQueryOptions(value);
+  };
 
   return (
-    <>
-      {/* TODO IssueAdvancedFilter 컴포넌트 구현  */}
+    <VerticalStack>
+      <FilterHeader>
+        <IssueAdvancedFilter
+          searchValue={queryOptions}
+          onSearchChange={handleSearchChange}
+        />
+        <RightGroup>
+          {/* TODO 기능 구현 시 하드코딩 제거 */}
+          <LabelMilestoneTab milestoneCount={5} labelCount={3} />
+          <CreateIssueButton />
+        </RightGroup>
+      </FilterHeader>
+
       <IssueListContainer
         onChangeTab={status => setSelectedTab(status)}
         selected={selectedTab}
       />
-    </>
+    </VerticalStack>
   );
 }
+
+const FilterHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const RightGroup = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+`;

--- a/fe/src/shared/components/LabelMilestoneTab.tsx
+++ b/fe/src/shared/components/LabelMilestoneTab.tsx
@@ -1,0 +1,37 @@
+import { useNavigate } from 'react-router-dom';
+import TabButton from './TabButton';
+import TabItem from './TabItem';
+import MilestoneIcon from '@/assets/icons/milestone.svg?react';
+import LabelIcon from '@/assets/icons/label.svg?react';
+
+interface LabelMilestoneTabProps {
+  labelCount: number;
+  milestoneCount: number;
+}
+
+export default function LabelMilestoneTab({
+  labelCount,
+  milestoneCount,
+}: LabelMilestoneTabProps) {
+  const navigate = useNavigate();
+
+  const labelTab = (
+    <TabItem
+      icon={<LabelIcon width={16} />}
+      label="레이블"
+      count={labelCount}
+      onClick={() => navigate('/labels')}
+    />
+  );
+
+  const milestoneTab = (
+    <TabItem
+      icon={<MilestoneIcon width={16} />}
+      label="마일스톤"
+      count={milestoneCount}
+      onClick={() => navigate('/milestones')}
+    />
+  );
+
+  return <TabButton left={labelTab} right={milestoneTab} />;
+}

--- a/fe/src/shared/components/TabButton.tsx
+++ b/fe/src/shared/components/TabButton.tsx
@@ -1,0 +1,33 @@
+import styled from '@emotion/styled';
+import { type ReactNode } from 'react';
+
+interface TabButtonProps {
+  left: ReactNode;
+  right: ReactNode;
+}
+
+export default function TabButton({ left, right }: TabButtonProps) {
+  return (
+    <Container>
+      {left}
+      <Divider />
+      {right}
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  width: 320px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid ${({ theme }) => theme.borderColor.default};
+  border-radius: ${({ theme }) => theme.radius.medium};
+  overflow: hidden;
+`;
+
+const Divider = styled.div`
+  width: 1px;
+  height: 40px;
+  background-color: ${({ theme }) => theme.borderColor.default};
+`;

--- a/fe/src/shared/components/TabItem.tsx
+++ b/fe/src/shared/components/TabItem.tsx
@@ -1,0 +1,51 @@
+import styled from '@emotion/styled';
+import { type ReactNode } from 'react';
+
+interface TabItemProps {
+  icon: ReactNode;
+  label: string;
+  count: number;
+  onClick?: () => void;
+  isActive?: boolean;
+}
+export default function TabItem({
+  icon,
+  label,
+  count,
+  onClick,
+  isActive = false,
+}: TabItemProps) {
+  return (
+    <TabItemWrapper onClick={onClick} isActive={isActive}>
+      {icon}
+      <TabLabel isActive={isActive}>{`${label}(${count})`}</TabLabel>
+    </TabItemWrapper>
+  );
+}
+
+const TabItemWrapper = styled.button<{ isActive: boolean }>`
+  width: 160px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px 0;
+
+  cursor: pointer;
+
+  background-color: ${({ isActive, theme }) =>
+    isActive ? theme.surfaceColor.bold : theme.surfaceColor.default};
+  color: ${({ isActive, theme }) =>
+    isActive ? theme.textColor.strong : theme.textColor.default};
+
+  &:hover {
+    opacity: ${({ theme }) => theme.opacity.hover};
+  }
+`;
+
+const TabLabel = styled.span<{ isActive: boolean }>`
+  ${({ isActive, theme }) =>
+    isActive
+      ? theme.typography.selectedBold16
+      : theme.typography.availableMedium16};
+`;

--- a/fe/src/shared/styles/globalStyles.ts
+++ b/fe/src/shared/styles/globalStyles.ts
@@ -18,7 +18,7 @@ const globalStyle = (theme: Theme) => css`
     align-items: stretch;
     justify-content: flex-start;
     font-family: ${theme.typography.fontFamily};
-    background-color: ${theme.surfaceColor.strong};
+    background-color: ${theme.surfaceColor.default};
     color: ${theme.textColor.strong};
 
     transition:


### PR DESCRIPTION
## 📌 PR 제목

[Feature] 메인화면 툴바 버튼 라우팅 기능 및 필터 바 UI 구현

## ✅ 작업 요약

- 이슈 목록 상단에 필터바, 라벨, 마일스톤, 이슈 작성 버튼 추가
- 각 버튼 클릭 시 해당 페이지(`/labels`, `/milestones`, `/issues/new`)로 이동하는 라우팅 구현
- React Router의 `useNavigate`를 활용하여 페이지 리로드 없이 전환 처리

- 라벨/마일스톤 탭 버튼 및 필터바, 새 이슈 버튼을 이슈 리스트 페이지에 통합 적용

- 글로벌 스타일의 배경색 오류 수정

>현재 필터바는 UI 구조만 구현된 상태이며, 드롭다운 및 실제 필터링 기능은 추후 추가할 예정입니다.
탭 컴포넌트와 버튼 컴포넌트 역시 현재는 공용화를 염두에 두고 작업하였으나, 피그마 컴포넌트에서 정의된 다양한 타입 및 활성화 상태는 아직 반영되지 않았습니다.
이러한 부분은 이후 공용 컴포넌트로 분리하면서 점진적으로 확장할 계획입니다.

## ✅ 테스트 확인

- [x] 각 버튼 클릭 시 라벨/마일스톤/이슈 작성 페이지로 정상 이동되는지 확인
- [x] 글로벌 스타일 배경색 수정이 정상적으로 반영되었는지 확인

## 🧠 회고/고민

closes #9
