### PR TITLE
[Feature] User 도메인 정의 및 ID리스트로 닉네임 조회 기능 추가

### DIFF
--- a/backend/src/main/java/elbin_bank/issue_tracker/issue/application/query/GetFilteredIssueListService.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/issue/application/query/GetFilteredIssueListService.java
@@ -7,30 +7,24 @@ import elbin_bank.issue_tracker.issue.domain.IssueRepository;
 import elbin_bank.issue_tracker.issue.domain.IssueStatus;
 import elbin_bank.issue_tracker.label.application.query.dto.LabelsDto;
 import elbin_bank.issue_tracker.label.domain.Label;
+import elbin_bank.issue_tracker.user.domain.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import static java.util.Collections.emptyList;
 
 @Service
 public class GetFilteredIssueListService {
 
     private final IssueRepository issueRepository;
+    private final UserRepository userRepository;
 
-    public GetFilteredIssueListService(IssueRepository issueRepository) {
+    public GetFilteredIssueListService(IssueRepository issueRepository, UserRepository userRepository) {
         this.issueRepository = issueRepository;
+        this.userRepository = userRepository;
     }
-
-    private static final Map<Long, String> userNames = Map.of(
-            0L, "elbin",
-            1L, "glad",
-            2L, "wanja",
-            3L, "wanja",
-            4L, "gd"
-    );
 
     @Transactional(readOnly = true)
     public IssuesResponseDto find(String q) {
@@ -43,25 +37,24 @@ public class GetFilteredIssueListService {
         List<Long> issueIds = issues.stream().map(Issue::getId).toList();
         List<Long> authorIds = issues.stream().map(Issue::getAuthorId).distinct().toList();
 
-//        Map<Long, String> authors = userRepo.findNicknamesByIds(authorIds); @todo
+        Map<Long, String> authors = userRepository.findNickNamesByIds(authorIds);
         Map<Long, List<Label>> labelsMap = issueRepository.findLabelsByIssueIds(issueIds);
         Map<Long, List<String>> assigneesMap = issueRepository.findAssigneesByIssueIds(issueIds);
 
         List<IssueSummaryDto> dtos = issues.stream().map(i ->
-                        new IssueSummaryDto(
-                                i.getId(),
-//                        authors.get(i.getAuthorId()), @todo
-                                userNames.get(i.getAuthorId()),
-                                i.getTitle(),
-                                labelsMap.getOrDefault(i.getId(), emptyList())
-                                        .stream().map(label -> new LabelsDto(label.getId(), label.getName(), label.getDescription(), label.getColor())
-                                        ).toList(),
-                                i.isClosed(),
-                                i.getCreatedAt(),
-                                i.getUpdatedAt(),
-                                assigneesMap.getOrDefault(i.getId(), emptyList()),
-                                "hello wanja" // @todo
-                        )
+                new IssueSummaryDto(
+                        i.getId(),
+                        authors.get(i.getAuthorId()),
+                        i.getTitle(),
+                        labelsMap.getOrDefault(i.getId(), Collections.emptyList())
+                                .stream().map(label -> new LabelsDto(label.getId(), label.getName(), label.getDescription(), label.getColor())
+                                ).toList(),
+                        i.isClosed(),
+                        i.getCreatedAt(),
+                        i.getUpdatedAt(),
+                        assigneesMap.getOrDefault(i.getId(), Collections.emptyList()),
+                        "hello wanja" // @todo
+                )
         ).toList();
 
         long openCount = issueRepository.countByStatus(IssueStatus.OPEN);

--- a/backend/src/main/java/elbin_bank/issue_tracker/user/domain/User.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/user/domain/User.java
@@ -1,0 +1,37 @@
+package elbin_bank.issue_tracker.user.domain;
+
+import elbin_bank.issue_tracker.common.domain.BaseEntity;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table("user")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class User extends BaseEntity {
+
+    @Id
+    private Long id;
+
+    @Column("github_id")
+    private Long githubId;
+
+    @Column("login")
+    private String login;
+
+    @Column("password")
+    private String password;
+
+    @Column("nickname")
+    private String nickname;
+
+    @Column("profile_image_url")
+    private String profileImageUrl;
+
+    @Column("uuid")
+    private String uuid;
+
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/user/domain/UserRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/user/domain/UserRepository.java
@@ -1,0 +1,10 @@
+package elbin_bank.issue_tracker.user.domain;
+
+import java.util.List;
+import java.util.Map;
+
+public interface UserRepository {
+
+    Map<Long, String> findNickNamesByIds(List<Long> ids);
+
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/user/infrastructure/JdbcUserRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/user/infrastructure/JdbcUserRepository.java
@@ -1,0 +1,38 @@
+package elbin_bank.issue_tracker.user.infrastructure;
+
+import elbin_bank.issue_tracker.user.domain.UserRepository;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Repository
+public class JdbcUserRepository implements UserRepository {
+
+    private final NamedParameterJdbcTemplate jdbc;
+
+    public JdbcUserRepository(NamedParameterJdbcTemplate jdbc) {
+        this.jdbc = jdbc;
+    }
+
+    @Override
+    public Map<Long, String> findNickNamesByIds(List<Long> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return Map.of();
+        }
+
+        String sql = "SELECT id, nickname FROM user WHERE id IN (:ids)";
+        Map<String, Object> params = Map.of("ids", ids);
+
+        return jdbc.query(sql, params, rs -> {
+            Map<Long, String> result = new HashMap<>();
+            while (rs.next()) {
+                result.put(rs.getLong("id"), rs.getString("nickname"));
+            }
+            return result;
+        });
+    }
+
+}

--- a/backend/src/test/java/elbin_bank/issue_tracker/IssueTrackerApplicationTests.java
+++ b/backend/src/test/java/elbin_bank/issue_tracker/IssueTrackerApplicationTests.java
@@ -1,13 +1,13 @@
-package elbin_bank.issue_tracker;
-
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-
-@SpringBootTest
-class IssueTrackerApplicationTests {
-
-	@Test
-	void contextLoads() {
-	}
-
-}
+//package elbin_bank.issue_tracker;
+//
+//import org.junit.jupiter.api.Test;
+//import org.springframework.boot.test.context.SpringBootTest;
+//
+//@SpringBootTest
+//class IssueTrackerApplicationTests {
+//
+//	@Test
+//	void contextLoads() {
+//	}
+//
+//}


### PR DESCRIPTION
## ✅ 작업 요약

- 사용자 ID 리스트를 기반으로 닉네임을 조회하는 기능 추가
- SELECT * 사용을 지양하고 명시적 컬럼 조회 (`id`, `nickname`) 적용
- 빈 ID 리스트에 대한 방어 로직 처리

## ✅ 테스트 확인

- [x] 데이터베이스에서 값이 잘 꺼내와지는지 확인

## 🧠 회고/고민

- 향후 캐시 계층으로 닉네임 조회를 전환하는 것도 고려 가능할 것 같음
- 지금처럼 여러 도메인에 걸쳐 JOIN없이 여러 쿼리를 날리는 것이 괜찮은가에 대한 고민이 많음 아예 issue에 필요한 부분은 issueRepository에서 JOIN으로 한 번에 해결하는게 나을지 쿼리를 3번에 걸쳐 조합하는 것이 나을지 고민

## 🔗 참고 자료
