### PR TITLE
[Feature] 열린이슈 닫힌이슈 아이콘 수정

### DIFF
--- a/fe/src/features/issue/components/list/IssueTabFilter.tsx
+++ b/fe/src/features/issue/components/list/IssueTabFilter.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
-import OpenIcon from '@/assets/icons/archive.svg?react';
-import ClosedIcon from '@/assets/icons/alertCircle.svg?react';
+import ClosedIcon from '@/assets/icons/archive.svg?react';
+import OpenIcon from '@/assets/icons/alertCircle.svg?react';
 
 interface TabItemProps {
   icon: React.ReactNode;


### PR DESCRIPTION
## ✅ 작업 요약

- 이슈 목록 상단의 열린이슈/닫힌이슈 전환 탭의 아이콘이 뒤바뀌어있던 문제 수정

## ✅ 테스트 확인

- [x] 열린이슈 닫힌이슈 아이콘이 기획 디자인과 일치함을 확인

### 수정된 아이콘

<img width="379" alt="image" src="https://github.com/user-attachments/assets/86d3d897-95e3-4964-add6-ab4adfaebb96" />
