### PR TITLE
[Feature] 테마 컬러 시스템 구조 개선

### DIFF
--- a/fe/src/features/issue/components/list/IssueAdvancedFilter.tsx
+++ b/fe/src/features/issue/components/list/IssueAdvancedFilter.tsx
@@ -37,7 +37,7 @@ const FilterWrapper = styled.div`
   align-items: center;
   overflow: hidden;
   border-radius: ${({ theme }) => theme.radius.medium};
-  border: 1px solid ${({ theme }) => theme.borderColor.default};
+  border: 1px solid ${({ theme }) => theme.neutral.border.default};
 `;
 
 const FilterButton = styled.button`
@@ -46,8 +46,8 @@ const FilterButton = styled.button`
   gap: 4px;
   padding: 4px 24px;
   border: none;
-  background-color: ${({ theme }) => theme.surfaceColor.default};
-  color: ${({ theme }) => theme.textColor.default};
+  background-color: ${({ theme }) => theme.neutral.surface.default};
+  color: ${({ theme }) => theme.neutral.text.default};
   ${({ theme }) => theme.typography.availableMedium16};
   cursor: pointer;
 `;
@@ -59,15 +59,15 @@ const SearchArea = styled.label`
   gap: 8px;
   padding: 8px 24px;
   height: 100%;
-  border-left: 1px solid ${({ theme }) => theme.borderColor.default};
-  background-color: ${({ theme }) => theme.surfaceColor.bold};
-  color: ${({ theme }) => theme.textColor.default};
+  border-left: 1px solid ${({ theme }) => theme.neutral.border.default};
+  background-color: ${({ theme }) => theme.neutral.surface.bold};
+  color: ${({ theme }) => theme.neutral.text.default};
 `;
 
 const SearchInput = styled.input`
   all: unset;
   flex: 1;
-  color: ${({ theme }) => theme.textColor.weak};
+  color: ${({ theme }) => theme.neutral.text.weak};
   ${({ theme }) => theme.typography.availableMedium16};
 `;
 

--- a/fe/src/features/issue/components/list/IssueListContainer.tsx
+++ b/fe/src/features/issue/components/list/IssueListContainer.tsx
@@ -52,9 +52,9 @@ export default function IssueListContainer({
 }
 
 const Container = styled.section`
-  border: 1px solid ${({ theme }) => theme.borderColor.default};
+  border: 1px solid ${({ theme }) => theme.neutral.border.default};
   border-radius: ${({ theme }) => theme.radius.medium};
-  background-color: ${({ theme }) => theme.surfaceColor.default};
+  background-color: ${({ theme }) => theme.neutral.surface.default};
   overflow: hidden;
 
   display: flex;

--- a/fe/src/features/issue/components/list/IssueListContent.tsx
+++ b/fe/src/features/issue/components/list/IssueListContent.tsx
@@ -47,6 +47,6 @@ const Message = ({
 const MessageItem = styled.li<{ isError?: boolean }>`
   padding: 40px 0;
   text-align: center;
-  color: ${({ isError, theme }) => (isError ? 'red' : theme.textColor.weak)};
+  color: ${({ isError, theme }) => (isError ? 'red' : theme.neutral.text.weak)};
   ${({ theme }) => theme.typography.availableMedium16};
 `;

--- a/fe/src/features/issue/components/list/IssueListHeader.tsx
+++ b/fe/src/features/issue/components/list/IssueListHeader.tsx
@@ -44,9 +44,9 @@ const HeaderWrapper = styled.div`
   align-items: center;
   padding: 16px 32px;
 
-  border-bottom: 1px solid ${({ theme }) => theme.borderColor.default};
-  background-color: ${({ theme }) => theme.surfaceColor.default};
-  color: ${({ theme }) => theme.textColor.default};
+  border-bottom: 1px solid ${({ theme }) => theme.neutral.border.default};
+  background-color: ${({ theme }) => theme.neutral.surface.default};
+  color: ${({ theme }) => theme.neutral.text.default};
   ${({ theme }) => theme.typography.availableMedium16};
 `;
 

--- a/fe/src/features/issue/components/list/IssueTabFilter.tsx
+++ b/fe/src/features/issue/components/list/IssueTabFilter.tsx
@@ -60,7 +60,7 @@ const TabButton = styled.button<{ active?: boolean }>`
   gap: 4px;
   padding: 4px 0;
   color: ${({ active, theme }) =>
-    active ? theme.textColor.strong : theme.textColor.default};
+    active ? theme.neutral.text.strong : theme.neutral.text.default};
   ${({ theme }) => theme.typography.selectedBold16};
 
   cursor: pointer;

--- a/fe/src/features/issue/components/list/issueItem/Assignees.tsx
+++ b/fe/src/features/issue/components/list/issueItem/Assignees.tsx
@@ -52,6 +52,6 @@ const ExtraText = styled.span`
   position: relative;
   z-index: 0;
 
-  color: ${({ theme }) => theme.textColor.strong};
+  color: ${({ theme }) => theme.neutral.text.strong};
   ${({ theme }) => theme.typography.displayMedium12};
 `;

--- a/fe/src/features/issue/components/list/issueItem/MetaInfo.tsx
+++ b/fe/src/features/issue/components/list/issueItem/MetaInfo.tsx
@@ -36,7 +36,7 @@ const Wrapper = styled.div`
   display: flex;
   align-items: center;
   gap: 16px;
-  color: ${({ theme }) => theme.textColor.weak};
+  color: ${({ theme }) => theme.neutral.text.weak};
   ${({ theme }) => theme.typography.displayMedium16};
 `;
 

--- a/fe/src/features/issue/components/list/issueItem/TitleWithLabels.tsx
+++ b/fe/src/features/issue/components/list/issueItem/TitleWithLabels.tsx
@@ -45,7 +45,7 @@ const TitleRow = styled.div`
 `;
 
 const IssueTitle = styled.span`
-  color: ${({ theme }) => theme.textColor.strong};
+  color: ${({ theme }) => theme.neutral.text.strong};
   ${({ theme }) => theme.typography.availableMedium20};
   cursor: pointer;
 `;

--- a/fe/src/features/issue/components/list/issueItem/index.tsx
+++ b/fe/src/features/issue/components/list/issueItem/index.tsx
@@ -53,15 +53,15 @@ const IssueItemWrapper = styled.li`
   align-items: center;
   justify-content: space-between;
   padding: 16px 32px;
-  border-bottom: 1px solid ${({ theme }) => theme.borderColor.default};
-  background-color: ${({ theme }) => theme.surfaceColor.strong};
+  border-bottom: 1px solid ${({ theme }) => theme.neutral.border.default};
+  background-color: ${({ theme }) => theme.neutral.surface.strong};
 
   &:last-of-type {
     border-bottom: none;
   }
 
   &:hover {
-    background-color: ${({ theme }) => theme.surfaceColor.default};
+    background-color: ${({ theme }) => theme.neutral.surface.default};
   }
 `;
 

--- a/fe/src/shared/components/Header.tsx
+++ b/fe/src/shared/components/Header.tsx
@@ -30,7 +30,7 @@ const LeftSection = styled.div`
 const StyledLogo = styled(Logo)`
   width: 199px;
   height: 40px;
-  color: ${({ theme }) => theme.textColor.strong};
+  color: ${({ theme }) => theme.neutral.text.strong};
 `;
 
 // TODO profile 공통 컴포넌트 분리

--- a/fe/src/shared/components/TabButton.tsx
+++ b/fe/src/shared/components/TabButton.tsx
@@ -21,7 +21,7 @@ const Container = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  border: 1px solid ${({ theme }) => theme.borderColor.default};
+  border: 1px solid ${({ theme }) => theme.neutral.border.default};
   border-radius: ${({ theme }) => theme.radius.medium};
   overflow: hidden;
 `;
@@ -29,5 +29,5 @@ const Container = styled.div`
 const Divider = styled.div`
   width: 1px;
   height: 40px;
-  background-color: ${({ theme }) => theme.borderColor.default};
+  background-color: ${({ theme }) => theme.neutral.border.default};
 `;

--- a/fe/src/shared/components/TabItem.tsx
+++ b/fe/src/shared/components/TabItem.tsx
@@ -34,9 +34,9 @@ const TabItemWrapper = styled.button<{ isActive: boolean }>`
   cursor: pointer;
 
   background-color: ${({ isActive, theme }) =>
-    isActive ? theme.surfaceColor.bold : theme.surfaceColor.default};
+    isActive ? theme.neutral.surface.bold : theme.neutral.surface.default};
   color: ${({ isActive, theme }) =>
-    isActive ? theme.textColor.strong : theme.textColor.default};
+    isActive ? theme.neutral.text.strong : theme.neutral.text.default};
 
   &:hover {
     opacity: ${({ theme }) => theme.opacity.hover};

--- a/fe/src/shared/styles/globalStyles.ts
+++ b/fe/src/shared/styles/globalStyles.ts
@@ -18,8 +18,8 @@ const globalStyle = (theme: Theme) => css`
     align-items: stretch;
     justify-content: flex-start;
     font-family: ${theme.typography.fontFamily};
-    background-color: ${theme.surfaceColor.default};
-    color: ${theme.textColor.strong};
+    background-color: ${theme.neutral.surface.default};
+    color: ${theme.neutral.text.strong};
 
     transition:
       background-color 0.2s ease,

--- a/fe/src/shared/styles/theme.common.ts
+++ b/fe/src/shared/styles/theme.common.ts
@@ -1,4 +1,5 @@
 import typography from './typography';
+import { accent } from './color';
 
 const commonTheme = {
   typography,
@@ -18,9 +19,9 @@ const commonTheme = {
     disabled: 0.32,
   },
   palette: {
-    blue: '#007AFF',
-    navy: '#0025E6',
-    red: '#FF3B30',
+    blue: accent.blue,
+    navy: accent.navy,
+    red: accent.red,
   },
 };
 

--- a/fe/src/shared/styles/theme.ts
+++ b/fe/src/shared/styles/theme.ts
@@ -2,62 +2,95 @@ import { grayscale, accent } from './color';
 import commonTheme from './theme.common';
 
 export const lightTheme = {
-  textColor: {
-    weak: grayscale[600],
-    default: grayscale[700],
-    strong: grayscale[900],
+  neutral: {
+    text: {
+      weak: grayscale[600],
+      default: grayscale[700],
+      strong: grayscale[900],
+    },
+    surface: {
+      default: grayscale[100],
+      bold: grayscale[200],
+      strong: grayscale[50],
+    },
+    border: {
+      default: grayscale[300],
+      active: grayscale[900],
+    },
   },
-  surfaceColor: {
-    default: grayscale[100],
-    bold: grayscale[200],
-    strong: grayscale[50],
-    weak: grayscale[50],
+  brand: {
+    text: {
+      weak: accent.blue,
+      default: grayscale[50],
+    },
+    surface: {
+      weak: grayscale[50],
+      default: accent.blue,
+    },
+    border: {
+      default: accent.blue,
+    },
   },
-  borderColor: {
-    default: grayscale[300],
-    active: grayscale[900],
+  danger: {
+    text: {
+      default: accent.red,
+    },
+    surface: {
+      default: accent.red,
+    },
+    border: {
+      default: accent.red,
+    },
   },
-  brandColor: {
-    textWeak: accent.blue,
-    default: accent.blue,
-  },
-  dangerColor: {
-    text: accent.red,
-    surface: accent.red,
-    border: accent.red,
-  },
-  shadow: '0px 8px 16px rgba(20, 20, 43, 0.04)',
 
+  shadow: '0px 8px 16px rgba(20, 20, 43, 0.04)',
   ...commonTheme,
 };
 
 export const darkTheme = {
-  textColor: {
-    weak: grayscale[500],
-    default: grayscale[400],
-    strong: grayscale[50],
+  neutral: {
+    text: {
+      weak: grayscale[500],
+      default: grayscale[400],
+      strong: grayscale[50],
+    },
+    surface: {
+      default: grayscale[900],
+      bold: grayscale[700],
+      strong: grayscale[800],
+      weak: grayscale[900],
+    },
+    border: {
+      default: grayscale[600],
+      active: grayscale[300],
+    },
   },
-  surfaceColor: {
-    default: grayscale[900],
-    bold: grayscale[700],
-    strong: grayscale[800],
-    weak: grayscale[900],
+  brand: {
+    text: {
+      weak: accent.blue,
+      default: grayscale[50],
+    },
+    surface: {
+      weak: grayscale[900],
+      default: accent.blue,
+    },
+    border: {
+      default: accent.blue,
+    },
   },
-  borderColor: {
-    default: grayscale[600],
-    active: grayscale[300],
+  danger: {
+    text: {
+      default: accent.red,
+    },
+    surface: {
+      default: accent.red,
+    },
+    border: {
+      default: accent.red,
+    },
   },
-  brandColor: {
-    textWeak: accent.blue,
-    default: accent.blue,
-  },
-  dangerColor: {
-    text: accent.red,
-    surface: accent.red,
-    border: accent.red,
-  },
-  shadow: '0px 8px 16px rgba(20, 20, 43, 0.8)',
 
+  shadow: '0px 8px 16px rgba(20, 20, 43, 0.8)',
   ...commonTheme,
 };
 


### PR DESCRIPTION
## 📌 PR 제목  
테마 컬러 토큰 구조를 역할 기반에서 의미 기반으로 리팩토링

## ✅ 작업 요약

- 기존 `textColor`, `surfaceColor`, `brandColor` 등 역할 중심의 키를 제거하고, 의미 중심(`neutral`, `brand`, `danger`, `palette`)의 토큰 구조로 재구성했습니다.
- 새로운 컬러 구조는 `semantic → role` 흐름으로 구성되며, 추후 다크 테마 확장이나 브랜드 리디자인에 유연하게 대응할 수 있도록 설계했습니다.
- 모든 테마 사용처에서 변경된 구조를 반영하여 오류 없이 동작하도록 수정했습니다.

## ✅ 테스트 확인

- [x] 기존 UI 컴포넌트가 새로운 컬러 토큰으로 정상 렌더링됨
- [x] 색상 타입 오류 없이 정상 컴파일

## 🧠 회고/고민

- **기존 역할 기반 구조의 한계**  
  `textColor.strong`, `surfaceColor.bold` 같은 구조는 직관성이 낮고, 새로운 상황에서의 유연한 확장에 불리했습니다. 특히 컴포넌트 단위에서 어떤 색을 써야 하는지 판단이 어려웠고, 의미의 충돌도 자주 발생했습니다.

- **의미 기반 구조로의 전환 이유**  
  `neutral`, `brand`, `danger` 등의 의미 단위로 먼저 나눈 후, 그 안에서 강도(100, 200, 300…)나 맥락(role)을 구분하면 훨씬 직관적인 토큰 설계가 가능해졌습니다. 예: `theme.palette.brand.500` → 브랜딩 목적의 주요 색상

- **단방향 참조 흐름 유지 고민**  
  `theme.color → common, theme` 흐름처럼, 테마 구조 내에서 참조의 방향이 일관되게 유지되도록 신경 썼습니다.  
  이로 인해 토큰을 어디에 정의하고, 어디에서 참조해야 할지가 명확해졌습니다.

- **palette 분리의 필요성**  
  디자인 시스템 내에서 실제 색상값(`#000`, `#FFF`)은 `palette`에서 한 번만 정의하고, 의미/역할은 상위 테마에서 조합하도록 하여 중복 없이 재사용이 가능해졌습니다.

closes #34 