### PR TITLE
[Fix] 배포 API 실패 문제 해결 및 .env 파일 Git 추적 제거

### DIFF
--- a/fe/.gitignore
+++ b/fe/.gitignore
@@ -14,6 +14,9 @@ dist-ssr
 
 .vite/
 
+.env
+.env.*
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/fe/src/shared/constants/api.ts
+++ b/fe/src/shared/constants/api.ts
@@ -1,7 +1,6 @@
 const API_VERSION = '/api/v1';
-const API_HOST = import.meta.env.VITE_API_HOST; // 환경변수로 도메인 관리
 
-export const API_BASE_URL = `${API_HOST}${API_VERSION}`;
+export const API_BASE_URL = `${API_VERSION}`;
 
 export const API = {
   ISSUES: `${API_BASE_URL}/issues`,

--- a/fe/vite.config.ts
+++ b/fe/vite.config.ts
@@ -1,25 +1,21 @@
-import { defineConfig, loadEnv } from 'vite';
+import { defineConfig } from 'vite';
 import path from 'path';
 import react from '@vitejs/plugin-react';
 import svgr from 'vite-plugin-svgr';
 
-export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd());
-
-  return {
-    plugins: [react(), svgr()],
-    resolve: {
-      alias: {
-        '@': path.resolve(__dirname, 'src'),
+export default defineConfig({
+  plugins: [react(), svgr()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
       },
     },
-    server: {
-      proxy: {
-        '/api': {
-          target: env.VITE_API_HOST,
-          changeOrigin: true,
-        },
-      },
-    },
-  };
+  },
 });


### PR DESCRIPTION
## 📌 PR 제목
[Fix] 배포 API 실패 문제 해결 및 .env 파일 Git 추적 제거

## ✅ 작업 요약

### 🐛 버그 수정
- **API 요청 실패 문제 해결**: 빌드 시점에 고정된 환경변수(`VITE_API_HOST`) 사용을 제거하고, API 요청 경로를 상대 경로(`/api/...`)로 변경하여 배포 환경에서의 API 호출 오류(CORS 포함)를 방지함
- 개발 환경에서는 Vite의 `proxy` 설정을 통해 `/api` 요청을 로컬 서버(`localhost:8080`)로 우회하도록 유지
- **.env 파일 정리**: 환경변수 사용이 불필요해짐에 따라 `.env` 파일을 삭제하고, `.gitignore`에 등록하여 추적되지 않도록 처리함

## ✅ 테스트 확인

- [x] 배포 환경에서 `.env` 없이도 API 요청이 정상적으로 작동하는지 확인
- [x] 로컬 개발 서버에서 proxy 설정을 통한 요청이 정상적으로 동작하는지 확인
- [x] `.env` 파일이 다시 생성되어도 Git에서 추적되지 않는지 확인

## 🧠 회고/고민


### 1. **배포 환경에 따라 API 경로 설정은 어떻게 달라져야 할까?**

#### 🧐 **고민의 배경**

- 개발 초기에는 `VITE_API_HOST` 환경변수를 통해 API 도메인을 지정하고, `const API_HOST = import.meta.env.VITE_API_HOST;` 방식으로 API 요청의 baseURL을 구성했습니다.
- 하지만 배포는 직접 하지 않았기 때문에, **실제 배포 환경에서 프론트와 백엔드가 같은 도메인을 사용하는 구조**라는 점을 처음에는 인지하지 못했습니다.
- 도메인이 다를 것이라 생각하고 로컬 기준(`localhost:8080`)을 `.env`에 작성했지만, 배포 후에는 예상과 다르게 동작하며 CORS 오류가 발생했습니다.

#### 🔎 **문제 분석 및 학습 과정**

- 배포 환경의 구조를 다시 확인하고 팀원과 소통한 결과, **프론트엔드와 백엔드가 동일 도메인에서 서비스되고 있음**을 알게 되었습니다.
- 이에 따라 공부를 통해 알게 된 사실은 다음과 같았습니다:

  1. Vite의 `import.meta.env`는 **런타임이 아닌 빌드 시점에 문자열로 고정**되므로, 빌드시 `.env`에 지정된 값이 하드코딩됩니다.
  2. 따라서 `http://localhost:8080`과 같은 값을 baseURL로 지정하면, 실제 배포 시 해당 값이 API 요청의 주소로 고정되어 문제가 발생합니다.
  3. 특히 CDN 등으로 정적 파일이 배포되는 경우, **도메인이 실행 시점에 결정**되기 때문에 빌드 시점에 도메인을 박아두는 방식은 매우 위험합니다.

#### ✅ **최종 해결**

- API 요청 경로를 **절대경로 → 상대경로(`/api/...`)**로 변경하여, 배포 환경에서도 현재 페이지의 도메인을 기준으로 API 요청이 이루어지도록 변경했습니다.
- 개발 환경에서는 Vite의 proxy 설정을 통해 `/api` 요청이 `localhost:8080`으로 프록시되도록 설정하여 문제없이 동작하도록 구성했습니다.
- `.env` 파일은 더 이상 필요하지 않아 삭제했고, Git 추적에서 제외하여 재발을 방지했습니다.

→ 이 과정을 통해 **배포 환경 구조에 대한 이해 부족이 실제 API 오류로 이어질 수 있다는 점**을 실감했고, 환경에 맞는 API 경로 설계의 중요성을 체득할 수 있었습니다.

closes #47 