### PR TITLE
[Fix] 필터 드롭다운 간격 버그 수정

### DIFF
--- a/fe/src/features/issue/components/list/IssueListHeader.tsx
+++ b/fe/src/features/issue/components/list/IssueListHeader.tsx
@@ -59,7 +59,7 @@ const LeftSection = styled.div`
 
 const RightSection = styled.div`
   display: flex;
-  gap: 16px;
+  gap: 32px;
 `;
 
 const Checkbox = styled.input`


### PR DESCRIPTION
## 📌 PR 제목  
필터 드롭다운 간격 버그 수정

## ✅ 작업 요약  
- 이슈 리스트 페이지 상단의 필터 드롭다운에서 텍스트와 인디케이터 사이 간격이 Figma 디자인보다 좁았던 문제를 수정  
- `gap` 값을 명시적으로 설정하여 시각적 일관성 확보

## ✅ 테스트 확인  
- [x] 드롭다운 인디케이터와 텍스트 간 간격이 Figma와 동일하게 적용됨  
- [x] 이슈 리스트 페이지에서 드롭다운 UI 정상 렌더링 확인

closes #42 