### PR TITLE
[Feature] 이슈 상세 페이지 베이스 구조 및 타이틀 클릭 이동 구현

### DIFF
--- a/fe/src/features/issue/components/Sidebar.tsx
+++ b/fe/src/features/issue/components/Sidebar.tsx
@@ -1,0 +1,3 @@
+export default function Sidebar() {
+  return <div>sidebar</div>;
+}

--- a/fe/src/features/issue/components/detail/CommentEditor.tsx
+++ b/fe/src/features/issue/components/detail/CommentEditor.tsx
@@ -1,0 +1,3 @@
+export default function CommentEditor() {
+  return <div>CommentEditor</div>;
+}

--- a/fe/src/features/issue/components/detail/CommentList.tsx
+++ b/fe/src/features/issue/components/detail/CommentList.tsx
@@ -1,0 +1,3 @@
+export default function CommentList() {
+  return <div>CommentList</div>;
+}

--- a/fe/src/features/issue/components/detail/IssueContent.tsx
+++ b/fe/src/features/issue/components/detail/IssueContent.tsx
@@ -1,0 +1,3 @@
+export default function IssueContent() {
+  return <div>IssueContent</div>;
+}

--- a/fe/src/features/issue/components/detail/IssueHeader.tsx
+++ b/fe/src/features/issue/components/detail/IssueHeader.tsx
@@ -1,0 +1,3 @@
+export default function IssueHeader() {
+  return <div>header</div>;
+}

--- a/fe/src/features/issue/components/detail/IssueMainSection.tsx
+++ b/fe/src/features/issue/components/detail/IssueMainSection.tsx
@@ -1,0 +1,21 @@
+import styled from '@emotion/styled';
+import IssueContent from './IssueContent';
+import CommentList from './CommentList';
+import CommentEditor from './CommentEditor';
+
+export default function IssueMainSection() {
+  return (
+    <MainWrapper>
+      <IssueContent />
+      <CommentList />
+      <CommentEditor />
+    </MainWrapper>
+  );
+}
+
+const MainWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  flex: 1;
+`;

--- a/fe/src/features/issue/components/list/issueItem/TitleWithLabels.tsx
+++ b/fe/src/features/issue/components/list/issueItem/TitleWithLabels.tsx
@@ -1,8 +1,10 @@
 import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
 import { getAccessibleLabelStyle } from '@/shared/utils/color';
 import { type Label } from '../../../types/issue';
 
 interface Props {
+  issueId: number;
   title: string;
   labels: Label[];
 }
@@ -13,10 +15,16 @@ interface LabelTagProps {
   color: string;
 }
 
-const TitleWithLabels = ({ title, labels }: Props) => {
+const TitleWithLabels = ({ issueId, title, labels }: Props) => {
+  const navigate = useNavigate();
+
+  const handleClickTitle = () => {
+    navigate(`/issues/${issueId}`);
+  };
+
   return (
     <TitleRow>
-      <IssueTitle>{title}</IssueTitle>
+      <IssueTitle onClick={handleClickTitle}>{title}</IssueTitle>
       {labels.map(label => {
         const { textColor, borderColor } = getAccessibleLabelStyle(label.color);
 
@@ -48,6 +56,10 @@ const IssueTitle = styled.span`
   color: ${({ theme }) => theme.neutral.text.strong};
   ${({ theme }) => theme.typography.availableMedium20};
   cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
 `;
 
 const LabelTag = styled.span<LabelTagProps>`

--- a/fe/src/features/issue/components/list/issueItem/index.tsx
+++ b/fe/src/features/issue/components/list/issueItem/index.tsx
@@ -28,7 +28,7 @@ const IssueItem = ({
             <IconWrapper>
               <StatusIcon isClosed={isClosed} />
             </IconWrapper>
-            <TitleWithLabels title={title} labels={labels} />
+            <TitleWithLabels issueId={id} title={title} labels={labels} />
           </TitleRow>
           <MetaInfo
             id={id}

--- a/fe/src/pages/IssueDetailPage.tsx
+++ b/fe/src/pages/IssueDetailPage.tsx
@@ -1,3 +1,24 @@
+import styled from '@emotion/styled';
+import Divider from '@/shared/components/Divider';
+import IssueHeader from '@/features/issue/components/detail/IssueHeader';
+import IssueMainSection from '@/features/issue/components/detail/IssueMainSection';
+import Sidebar from '@/features/issue/components/Sidebar';
+import VerticalStack from '@/layouts/VerticalStack';
+
 export default function IssueDetailPage() {
-  return <div> 📋 IssueDetailPage (임시)</div>;
+  return (
+    <VerticalStack>
+      <IssueHeader />
+      <Divider />
+      <MainArea>
+        <IssueMainSection />
+        <Sidebar />
+      </MainArea>
+    </VerticalStack>
+  );
 }
+
+const MainArea = styled.div`
+  display: flex;
+  gap: 32px;
+`;

--- a/fe/src/shared/components/Divider.tsx
+++ b/fe/src/shared/components/Divider.tsx
@@ -1,0 +1,21 @@
+import styled from '@emotion/styled';
+
+interface DividerProps {
+  variant?: 'default' | 'bold';
+}
+
+interface DividerVariant {
+  variant: 'default' | 'bold';
+}
+
+export default function Divider({ variant = 'default' }: DividerProps) {
+  return <StyledDivider variant={variant} />;
+}
+
+const StyledDivider = styled.div<DividerVariant>`
+  height: 1px;
+  background-color: ${({ theme, variant }) =>
+    variant === 'bold'
+      ? theme.neutral.border.active
+      : theme.neutral.border.default};
+`;


### PR DESCRIPTION
## 📌 PR 제목

[Feature] 이슈 상세 페이지 구조 및 타이틀 클릭 이동 구현

## ✅ 작업 요약

- **이슈 상세 페이지 라우팅 및 기본 구조 설정**:  
  `/issues/:id` 라우트를 생성하고, 해당 URL로 접근 시 이슈 상세 페이지가 렌더링되도록 설정했습니다.  
  레이아웃은 좌측 본문 / 우측 사이드바 구조로 분리하였으며, 컴포넌트 계층만 설정하고 세부 스타일은 추후 적용 예정입니다.

- **이슈 타이틀 클릭 시 상세 페이지 이동 처리**:  
  이슈 리스트에서 타이틀 클릭 시 `useNavigate`를 사용하여 해당 이슈의 상세 페이지로 이동되도록 구현했습니다.

- **타이틀 호버 스타일 추가**:  
  사용자 경험 향상을 위해, 타이틀에 hover 시 underline 스타일을 적용했습니다.

- **Divider 컴포넌트 공용화**:  
  기본 / 굵은(bold) 스타일을 `variant` prop을 통해 설정할 수 있는 Divider 컴포넌트를 공용으로 생성했습니다.  
  전체 레이아웃에서 간격 분리 및 시각적 구분을 담당하는 역할로 사용됩니다.

## ✅ 테스트 확인  
- [x] 타이틀 클릭 시 이슈 상세 페이지로 정상 이동됨  
- [x] `/issues/:id` 경로에서 페이지가 정상 렌더링됨  
- [x] Divider 컴포넌트가 다양한 스타일로 재사용 가능함  
- [x] 타이틀 hover 시 underline 스타일 정상 적용됨

## 🧠 회고/고민

### 1. **Divider 컴포넌트를 어떻게 확장성 있게 설계할까?**

#### **고민의 배경**

- 상세 페이지 레이아웃 상에서 구분선이 여러 곳에 사용되며, 디자인에 따라 기본 선 또는 굵은 선 등 다양한 스타일이 요구될 수 있습니다.
- 따라서 한 가지 스타일로만 고정하기보다, 이후 요구사항이 생겨도 쉽게 대응할 수 있도록 설계하는 것이 좋을 것이라 판단되었습니다.

#### **최종 해결**

- `variant`라는 prop을 통해 Divider의 스타일을 **default** 또는 **bold**로 설정할 수 있게 했습니다.
- 추후 필요 시 더 다양한 스타일이나 여백 옵션을 추가할 수 있도록 구조를 유연하게 설계했습니다.
- 이렇게 공용 컴포넌트로 분리해두면 유지보수와 확장이 쉬워지고, 레이아웃 통일성도 확보할 수 있습니다.


closes #49 
