### PR TITLE
[Fix] 새 이슈 작성 버튼 클릭 시 이슈 상세로 이동하는 문제 수정

### DIFF
--- a/fe/src/app/router.tsx
+++ b/fe/src/app/router.tsx
@@ -19,7 +19,7 @@ const router = createBrowserRouter([
     children: [
       { index: true, element: <IssueListPage /> },
       { path: 'issues/:id', element: <IssueDetailPage /> },
-      { path: 'new', element: <NewIssuePage /> },
+      { path: 'issues/new', element: <NewIssuePage /> },
       { path: 'labels', element: <LabelsPage /> },
       { path: 'milestones', element: <MilestonesPage /> },
     ],


### PR DESCRIPTION
## 📌 PR 제목  
[Fix] 새 이슈 작성 버튼 클릭 시 이슈 상세로 이동하는 문제 수정

---

## ✅ 작업 요약  
- 기존 `/new`로 설정되어 있던 새 이슈 작성 페이지 라우터 경로를 `/issues/new`로 변경
- 새 이슈 작성 버튼의 링크 경로(`/issues/new`)와 통일되도록 수정
- 이슈 상세 경로(`/issues/:id`)와의 충돌을 방지하기 위해 라우터 설정 재정비

---

## 🧠 회고/고민  
- 초기에는 라우터를 `/new`로 설정했으나, 페이지 목적을 명확히 하기 위해 `/issues/new`로 수정
- 버튼과 라우터 경로가 일치하지 않아 잘못된 페이지로 이동하는 문제가 발생했으며, 경로 통일로 해결
- `issues/:id`와의 라우팅 충돌은 React Router의 정적 경로 우선 규칙에 따라 발생하지 않지만, 명확한 설계 기준 마련을 위해 경로 체계를 정비함

closes #72 