### PR TITLE
[chore] vitest-fetch-mock 추가 및 테스트 타입 선언 설정

### DIFF
--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -40,7 +40,8 @@
         "typescript-eslint": "^8.30.1",
         "vite": "^6.3.5",
         "vite-plugin-svgr": "^4.3.0",
-        "vitest": "^3.1.4"
+        "vitest": "^3.1.4",
+        "vitest-fetch-mock": "^0.4.5"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -7484,6 +7485,19 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest-fetch-mock": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/vitest-fetch-mock/-/vitest-fetch-mock-0.4.5.tgz",
+      "integrity": "sha512-nhWdCQIGtaSEUVl96pMm0WggyDGPDv5FUy/Q9Hx3cs2RGmh3Q/uRsLClGbdG3kXBkJ3br5yTUjB2MeW25TwdOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "vitest": ">=2.0.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/fe/package.json
+++ b/fe/package.json
@@ -53,6 +53,7 @@
     "typescript-eslint": "^8.30.1",
     "vite": "^6.3.5",
     "vite-plugin-svgr": "^4.3.0",
-    "vitest": "^3.1.4"
+    "vitest": "^3.1.4",
+    "vitest-fetch-mock": "^0.4.5"
   }
 }

--- a/fe/tsconfig.app.json
+++ b/fe/tsconfig.app.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "typeRoots": ["./node_modules", "./src/types"],
-    "types": ["vite/client", "vitest/globals"],
+    "types": ["vite/client", "vitest/globals", "vitest", "vitest-fetch-mock"],
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2020",
     "useDefineForClassFields": true,


### PR DESCRIPTION
## 📌 PR 제목

[chore] vitest-fetch-mock 추가 및 테스트 타입 선언 설정


## ✅ 작업 요약

- `vitest-fetch-mock` 모듈을 `devDependencies`에 추가
- 테스트 환경에서 `fetch` mocking이 가능하도록 설정
- `tsconfig.json`에 `"types": ["vitest", "vitest-fetch-mock"]` 추가하여 타입 인식 설정


## ✅ 테스트 확인

- [x] 테스트에서 `fetch` mocking 정상 작동 확인
- [x] 타입 에러 없이 컴파일 완료


## 🧠 회고/고민

- 공식 문서에서는 `createFetchMock(vi)` 방식 사용을 권장하여 해당 방식을 도입함
- `fetchMock.enableMocks()` 방식은 타입 불일치 및 상태 공유 문제로 지양함
- 테스트 격리성과 명시적 설정을 고려해 `createFetchMock` 기반 설정으로 통일

## 🔗 참고 자료

- [vitest-fetch-mock 공식 문서](https://github.com/aaronj1335/vitest-fetch-mock)
- [Vitest 테스트 환경 설정 가이드](https://vitest.dev/guide/)

closes #77 