### PR TITLE
[Feature] 이슈 상세 조회 훅 및 API 테스트 코드 추가

### DIFF
--- a/fe/src/features/issue/api/getIssueDetail.test.ts
+++ b/fe/src/features/issue/api/getIssueDetail.test.ts
@@ -1,0 +1,40 @@
+import getIssueDetail from './getIssueDetail';
+import { fetchMocker } from '@/setupTests';
+
+describe('getIssueDetail', () => {
+  it('should return issue detail when response is 200', async () => {
+    const mockData = { id: 1, title: 'Test Issue' };
+    fetchMocker.mockResponseOnce(JSON.stringify(mockData));
+
+    const result = await getIssueDetail(1);
+    expect(result).toEqual(mockData);
+  });
+
+  it('should throw 401 error message', async () => {
+    fetchMocker.mockResponseOnce('', { status: 401 });
+
+    await expect(getIssueDetail(1)).rejects.toThrow('로그인이 필요합니다');
+  });
+
+  it('should throw 404 error message', async () => {
+    fetchMocker.mockResponseOnce('', { status: 404 });
+
+    await expect(getIssueDetail(1)).rejects.toThrow(
+      '요청한 이슈가 존재하지 않습니다',
+    );
+  });
+
+  it('should throw 500 error message', async () => {
+    fetchMocker.mockResponseOnce('', { status: 500 });
+
+    await expect(getIssueDetail(1)).rejects.toThrow('서버 오류가 발생했습니다');
+  });
+
+  it('should throw fallback error for unknown status', async () => {
+    fetchMocker.mockResponseOnce('', { status: 403 });
+
+    await expect(getIssueDetail(1)).rejects.toThrow(
+      '예상치 못한 오류가 발생했습니다 (status: 403)',
+    );
+  });
+});

--- a/fe/src/features/issue/api/getIssueDetail.ts
+++ b/fe/src/features/issue/api/getIssueDetail.ts
@@ -1,0 +1,21 @@
+import { API } from '@/shared/constants/api';
+import { type IssueDetailResponse } from '../types/issue';
+
+export default async function getIssueDetail(
+  issueId: number,
+): Promise<IssueDetailResponse> {
+  const res = await fetch(`${API.ISSUES}/${issueId}`);
+
+  if (res.status === 200) return res.json();
+
+  const errorMessages: Record<number, string> = {
+    401: '로그인이 필요합니다',
+    404: '요청한 이슈가 존재하지 않습니다',
+    500: '서버 오류가 발생했습니다',
+  };
+
+  const message = errorMessages[res.status];
+  throw new Error(
+    message ?? `예상치 못한 오류가 발생했습니다 (status: ${res.status})`,
+  );
+}

--- a/fe/src/features/issue/hooks/useIssueDetail.ts
+++ b/fe/src/features/issue/hooks/useIssueDetail.ts
@@ -6,5 +6,6 @@ export default function useIssueDetail(issueId: number) {
     queryKey: ['issueDetail', issueId],
     queryFn: () => getIssueDetail(issueId),
     enabled: !!issueId,
+    retry: false,
   });
 }

--- a/fe/src/features/issue/hooks/useIssueDetail.ts
+++ b/fe/src/features/issue/hooks/useIssueDetail.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import getIssueDetail from '../api/getIssueDetail';
+
+export default function useIssueDetail(issueId: number) {
+  return useQuery({
+    queryKey: ['issueDetail', issueId],
+    queryFn: () => getIssueDetail(issueId),
+    enabled: !!issueId,
+  });
+}

--- a/fe/src/features/issue/types/issue.ts
+++ b/fe/src/features/issue/types/issue.ts
@@ -24,3 +24,36 @@ export interface IssuesResponse {
   openCount: number;
   closeCount: number;
 }
+
+export interface Milestone {
+  id: number;
+  name: string;
+  progressRate: number;
+}
+
+export interface Assignee {
+  id: number;
+  nickname: string;
+  profileImage: string;
+}
+
+export interface IssueDetailResponse {
+  issues: [
+    {
+      id: number;
+      author: {
+        id: number;
+        nickname: string;
+        profileImage: string;
+      };
+      title: string;
+      content: string;
+      labels: Label[];
+      milestone: Milestone | null;
+      assignees: Assignee[];
+      isClosed: boolean;
+      createdAt: string;
+      updatedAt: string;
+    },
+  ];
+}

--- a/fe/src/pages/IssueDetailPage.tsx
+++ b/fe/src/pages/IssueDetailPage.tsx
@@ -1,4 +1,6 @@
 import styled from '@emotion/styled';
+import { useParams } from 'react-router-dom';
+import useIssueDetail from '@/features/issue/hooks/useIssueDetail';
 import Divider from '@/shared/components/Divider';
 import IssueHeader from '@/features/issue/components/detail/IssueHeader';
 import IssueMainSection from '@/features/issue/components/detail/IssueMainSection';
@@ -6,6 +8,19 @@ import Sidebar from '@/features/issue/components/Sidebar';
 import VerticalStack from '@/layouts/VerticalStack';
 
 export default function IssueDetailPage() {
+  const { id } = useParams();
+  const issueId = Number(id);
+
+  const {
+    data: issueDetailData,
+    isLoading: isIssueDetailLoading,
+    error: IssueDetailError,
+  } = useIssueDetail(issueId);
+
+  // TODO 로딩,에러 상태에 따라 분기처리 내부적으로 처리
+  if (isIssueDetailLoading) return <div>로딩 중...</div>;
+  if (IssueDetailError) return <div>에러 발생</div>;
+
   return (
     <VerticalStack>
       <IssueHeader />

--- a/fe/src/pages/IssueDetailPage.tsx
+++ b/fe/src/pages/IssueDetailPage.tsx
@@ -1,5 +1,6 @@
+import { useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import styled from '@emotion/styled';
-import { useParams } from 'react-router-dom';
 import useIssueDetail from '@/features/issue/hooks/useIssueDetail';
 import Divider from '@/shared/components/Divider';
 import IssueHeader from '@/features/issue/components/detail/IssueHeader';
@@ -10,16 +11,24 @@ import VerticalStack from '@/layouts/VerticalStack';
 export default function IssueDetailPage() {
   const { id } = useParams();
   const issueId = Number(id);
+  const navigate = useNavigate();
 
   const {
     data: issueDetailData,
     isLoading: isIssueDetailLoading,
-    error: IssueDetailError,
+    isError: isIssueDetailError,
   } = useIssueDetail(issueId);
+
+  //TODO 에러 종류에 따라 분기 처리
+  useEffect(() => {
+    if (isIssueDetailError) {
+      navigate('/404', { replace: true });
+    }
+  }, [isIssueDetailError]);
 
   // TODO 로딩,에러 상태에 따라 분기처리 내부적으로 처리
   if (isIssueDetailLoading) return <div>로딩 중...</div>;
-  if (IssueDetailError) return <div>에러 발생</div>;
+  if (isIssueDetailError) return <div>에러 발생</div>;
 
   return (
     <VerticalStack>

--- a/fe/src/setupTests.ts
+++ b/fe/src/setupTests.ts
@@ -3,7 +3,7 @@ import { vi, beforeEach, afterEach } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-const fetchMocker = createFetchMock(vi);
+export const fetchMocker = createFetchMock(vi);
 
 fetchMocker.enableMocks();
 

--- a/fe/src/shared/constants/api.ts
+++ b/fe/src/shared/constants/api.ts
@@ -5,4 +5,5 @@ export const API_BASE_URL = `${API_VERSION}`;
 export const API = {
   ISSUES: `${API_BASE_URL}/issues`,
   LABELS: `${API_BASE_URL}/labels`,
+  ISSUEDETAIL: `${API_BASE_URL}/issues`,
 };


### PR DESCRIPTION
## 📌 PR 제목

[Feature] 이슈 상세 조회 훅 및 API 테스트 코드 추가

## ✅ 작업 요약

#### 이슈 상세 데이터 패칭

- `useIssueDetail` 훅 구현: `react-query` 기반의 이슈 상세 데이터 요청 훅 추가
- `getIssueDetail` API 함수 및 `IssueDetail` 타입 정의
- 테스트 코드 작성: `getIssueDetail` 함수에 대해 정상 응답 및 다양한 에러 상황(401, 404, 500, 기타) 테스트 추가

#### Test 환경 관련
- `setupTests.ts`에 `fetchMocker` export 누락 수정

## ✅ 테스트 확인

- [x] `getIssueDetail`의 정상 응답 및 예외 상황 테스트 작성
- [x] 테스트 전부 통과 확인

## 🧠 회고/고민

### 1. `fetch-mock` 테스트 환경 설정 문제

- 테스트 코드에서 `fetchMocker`를 사용하려 했으나, `setupTests.ts`에서 export하지 않아 접근이 불가능했습니다.  
- 이를 해결하기 위해 `fetchMocker`를 export 처리하여, 테스트 코드에서 직접 사용 가능하도록 했습니다.  
→ 테스트 설정의 일관성과 재사용성을 확보했습니다.


### 2. 에러 핸들링 방식에 대한 구조적 고민

- `useIssueDetail` 훅 내부에서 에러 발생 시 `navigate`를 직접 호출하는 방식은 간단하지만,
  - 테스트가 어렵고
  - 훅의 재사용성과 관심사 분리가 깨진다는 문제가 있었습니다.
- 따라서 훅은 **에러 상태만 외부로 전달하고**, 실제 라우팅은 **컴포넌트 레벨에서 처리**하는 구조로 결정했습니다.  
→ 역할 분리가 명확해지고, 유지보수성과 확장성이 개선되었습니다.


### 3. `retry: false` 설정으로 UX 개선

- `react-query`의 기본 동작은 에러 발생 시 자동 재요청을 수행합니다.
- 하지만 이슈 상세 조회처럼 **존재하지 않는 리소스에 대한 요청**은 불필요한 재시도를 발생시킬 수 있어, `retry: false`로 명시적으로 비활성화했습니다.  
→ 불필요한 요청을 줄이고, 사용자에게 빠르게 피드백을 제공할 수 있도록 개선했습니다.


### 4. 잘못된 ID 접근 처리 로직의 한계와 계획

- 현재는 `isError`만으로 단순히 `/404`로 이동하도록 구성되어 있습니다.
- 그러나 이 방식은 404뿐 아니라 500, 401 등 **모든 종류의 에러를 동일하게 처리**하는 문제가 있습니다.
- 이는 **유지보수성과 사용자 경험 측면에서 명확한 한계를 가지며**,  
→ 추후 `error.response.status`를 기반으로 **HTTP status code별 분기 처리**를 통해 더 정교한 에러 대응 로직으로 리팩토링할 계획입니다.
- 이번 PR에서는 우선 기본적인 흐름만 잡아두는 수준으로 구성했습니다.
## 🔗 참고 자료

- [React Query - Handling Errors](https://tanstack.com/query/latest/docs/react/guides/query-errors)
- [vitest-fetch-mock 공식 문서](https://www.npmjs.com/package/vitest-fetch-mock)

closes #64 