### PR TITLE
[Feature] 댓글 목록 조회를 위한 useIssueComments 훅 구현

### DIFF
--- a/fe/src/features/issue/api/getIssueComments.test.ts
+++ b/fe/src/features/issue/api/getIssueComments.test.ts
@@ -1,0 +1,41 @@
+import { fetchMocker } from '@/setupTests';
+import getIssueComments from './getIssueComments';
+
+describe('getIssueComments', () => {
+  beforeEach(() => {
+    fetchMocker.resetMocks();
+  });
+
+  it('should fetch comments correctly', async () => {
+    fetchMocker.mockResponseOnce(
+      JSON.stringify({
+        comments: [
+          {
+            id: 1,
+            author: {
+              id: 10,
+              nickname: 'jjinbbangS2',
+              profileImage: 'https://example.com/avatar1.png',
+            },
+            content: '이 이슈에 동의합니다.',
+            createdAt: '2025-05-20T10:30:00.000Z',
+            updatedAt: '2025-05-20T10:30:00.000Z',
+          },
+        ],
+      }),
+      { status: 200 },
+    );
+
+    const result = await getIssueComments(101);
+    expect(result.comments).toHaveLength(1);
+    expect(result.comments[0].author.nickname).toBe('jjinbbangS2');
+  });
+
+  it('should throw error when status is 404', async () => {
+    fetchMocker.mockResponseOnce('', { status: 404 });
+
+    await expect(() => getIssueComments(999)).rejects.toThrow(
+      '요청한 이슈가 존재하지 않습니다',
+    );
+  });
+});

--- a/fe/src/features/issue/api/getIssueComments.ts
+++ b/fe/src/features/issue/api/getIssueComments.ts
@@ -1,0 +1,21 @@
+import { API } from '@/shared/constants/api';
+import { type CommentsResponse } from '../types/issue';
+
+export default async function getIssueComments(
+  issueId: number,
+): Promise<CommentsResponse> {
+  const res = await fetch(`${API.ISSUES}/${issueId}/comments`);
+
+  if (res.status === 200) return res.json();
+
+  const errorMessages: Record<number, string> = {
+    401: '로그인이 필요합니다',
+    404: '요청한 이슈가 존재하지 않습니다',
+    500: '서버 오류가 발생했습니다',
+  };
+
+  const message = errorMessages[res.status];
+  throw new Error(
+    message ?? `예상치 못한 오류가 발생했습니다 (status: ${res.status})`,
+  );
+}

--- a/fe/src/features/issue/components/detail/CommentList.tsx
+++ b/fe/src/features/issue/components/detail/CommentList.tsx
@@ -1,3 +1,22 @@
-export default function CommentList() {
-  return <div>CommentList</div>;
+import useIssueComments from '../../hooks/useIssueComments';
+import { type Comment } from '../../types/issue';
+
+interface CommentListProps {
+  issueId: number;
+}
+
+export default function CommentList({ issueId }: CommentListProps) {
+  const { data, isLoading, isError } = useIssueComments(issueId);
+
+  //TODO 에러나 로딩에 따른 구체적인 분기처리 필요
+  if (isLoading) return <div>로딩 중...</div>;
+  if (isError) return <div>댓글 불러오기 실패</div>;
+
+  return (
+    <ul>
+      {data?.comments.map((comment: Comment) => (
+        <li key={comment.id}>{comment.content}</li>
+      ))}
+    </ul>
+  );
 }

--- a/fe/src/features/issue/components/detail/IssueMainSection.tsx
+++ b/fe/src/features/issue/components/detail/IssueMainSection.tsx
@@ -3,11 +3,15 @@ import IssueContent from './IssueContent';
 import CommentList from './CommentList';
 import CommentEditor from './CommentEditor';
 
-export default function IssueMainSection() {
+interface IssueMainSectionProps {
+  issueId: number;
+}
+
+export default function IssueMainSection({ issueId }: IssueMainSectionProps) {
   return (
     <MainWrapper>
       <IssueContent />
-      <CommentList />
+      <CommentList issueId={issueId} />
       <CommentEditor />
     </MainWrapper>
   );

--- a/fe/src/features/issue/hooks/useIssueComments.ts
+++ b/fe/src/features/issue/hooks/useIssueComments.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import fetchIssueComments from '../api/getIssueComments';
+import { type CommentsResponse } from '../types/issue';
+
+export default function useIssueComments(issueId: number) {
+  return useQuery<CommentsResponse>({
+    queryKey: ['issueComments', issueId],
+    queryFn: () => fetchIssueComments(issueId),
+    enabled: !!issueId,
+    retry: false,
+  });
+}

--- a/fe/src/features/issue/types/issue.ts
+++ b/fe/src/features/issue/types/issue.ts
@@ -57,3 +57,21 @@ export interface IssueDetailResponse {
     },
   ];
 }
+
+export interface CommentAuthor {
+  id: number;
+  nickname: string;
+  profileImage: string;
+}
+
+export interface Comment {
+  id: number;
+  author: CommentAuthor;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CommentsResponse {
+  comments: Comment[];
+}

--- a/fe/src/pages/IssueDetailPage.tsx
+++ b/fe/src/pages/IssueDetailPage.tsx
@@ -35,7 +35,7 @@ export default function IssueDetailPage() {
       <IssueHeader />
       <Divider />
       <MainArea>
-        <IssueMainSection />
+        <IssueMainSection issueId={issueId} />
         <Sidebar />
       </MainArea>
     </VerticalStack>


### PR DESCRIPTION
## 📌 PR 제목

[Feature] 댓글 목록 조회를 위한 useIssueComments 훅 구현

## ✅ 작업 요약

- `useIssueComments` 훅을 생성하여 이슈 ID 기반으로 댓글 목록을 불러오는 기능을 구현했습니다.
- `getIssueComments` API 함수 및 관련 `Comment` 타입 정의를 추가했습니다.
- `CommentList` 컴포넌트에 훅을 적용하여 댓글 목록을 화면에 렌더링했습니다.
- `issueId`는 페이지 컴포넌트에서 props로 전달받아 사용합니다.

## ✅ 테스트 확인

- [x] getIssueComments가 예상된 구조의 댓글 배열을 반환하는지 테스트
- [x] 각 댓글의 `author.nickname`과 `content`가 올바르게 파싱되는지 확인
- [x] 404 응답에 대해 적절한 에러 메시지를 throw하는지 검증

## 🧠 회고/고민

### 1. **댓글 데이터를 어디서 fetch하고 내려줄지**

#### 고민의 배경
- 이슈 상세 페이지에서 댓글 목록을 보여주는 `CommentList` 컴포넌트를 만들며, 댓글 데이터를 어디에서 fetch할지 고민했습니다.
- **이슈 ID를 기준으로 데이터를 가져오고**, 이슈 상세 내 다른 컴포넌트에서도 사용할 수 있도록 범위를 고민했습니다.

#### 고려한 방식
1. **상위 페이지에서 fetch 후 props로 전달**
   - 장점: 한 번만 요청하고 여러 컴포넌트에 재사용 가능
   - 단점: props 드릴링 발생 + 로딩/에러 처리가 분산됨

2. **컴포넌트 내부에서 훅을 사용해 독립적으로 fetch**
   - 장점: 독립성과 재사용성 높음, 훅 기반으로 에러/로딩 처리 일원화
   - 단점: fetch 중복 가능성 있음

#### 최종 해결
- **`CommentList` 내부에서 `useIssueComments` 훅을 직접 호출**하는 구조를 선택했습니다.
- 페이지에서 issueId만 props로 내려받고, 댓글 관련 로직은 모두 훅 내부에서 처리하여 컴포넌트의 책임을 명확히 분리했습니다.
- 추후 다른 컴포넌트에서도 댓글이 필요하다면 동일한 훅을 재사용할 수 있도록 설계했습니다.

closes #55 

