### PR TITLE
[Fix] API 응답 구조 변경에 따른 타입 수정 및 평탄화 적용

### DIFF
--- a/fe/src/features/issue/api/getIssueComments.test.ts
+++ b/fe/src/features/issue/api/getIssueComments.test.ts
@@ -27,8 +27,8 @@ describe('getIssueComments', () => {
     );
 
     const result = await getIssueComments(101);
-    expect(result.comments).toHaveLength(1);
-    expect(result.comments[0].author.nickname).toBe('jjinbbangS2');
+    expect(result).toHaveLength(1);
+    expect(result[0].author.nickname).toBe('jjinbbangS2');
   });
 
   it('should throw error when status is 404', async () => {

--- a/fe/src/features/issue/api/getIssueComments.ts
+++ b/fe/src/features/issue/api/getIssueComments.ts
@@ -1,12 +1,15 @@
 import { API } from '@/shared/constants/api';
-import { type CommentsResponse } from '../types/issue';
+import { type CommentsResponse, type Comment } from '../types/issue';
 
 export default async function getIssueComments(
   issueId: number,
-): Promise<CommentsResponse> {
+): Promise<Comment[]> {
   const res = await fetch(`${API.ISSUES}/${issueId}/comments`);
 
-  if (res.status === 200) return res.json();
+  if (res.status === 200) {
+    const data: CommentsResponse = await res.json();
+    return data.comments;
+  }
 
   const errorMessages: Record<number, string> = {
     401: '로그인이 필요합니다',

--- a/fe/src/features/issue/hooks/useIssueComments.ts
+++ b/fe/src/features/issue/hooks/useIssueComments.ts
@@ -1,9 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 import fetchIssueComments from '../api/getIssueComments';
-import { type CommentsResponse } from '../types/issue';
+import { type Comment } from '../types/issue';
 
 export default function useIssueComments(issueId: number) {
-  return useQuery<CommentsResponse>({
+  return useQuery<Comment[]>({
     queryKey: ['issueComments', issueId],
     queryFn: () => fetchIssueComments(issueId),
     enabled: !!issueId,

--- a/fe/src/features/issue/types/issue.ts
+++ b/fe/src/features/issue/types/issue.ts
@@ -38,24 +38,20 @@ export interface Assignee {
 }
 
 export interface IssueDetailResponse {
-  issues: [
-    {
-      id: number;
-      author: {
-        id: number;
-        nickname: string;
-        profileImage: string;
-      };
-      title: string;
-      content: string;
-      labels: Label[];
-      milestone: Milestone | null;
-      assignees: Assignee[];
-      isClosed: boolean;
-      createdAt: string;
-      updatedAt: string;
-    },
-  ];
+  id: number;
+  author: {
+    id: number;
+    nickname: string;
+    profileImage: string;
+  };
+  title: string;
+  content: string;
+  labels: Label[];
+  milestone: Milestone | null;
+  assignees: Assignee[];
+  isClosed: boolean;
+  createdAt: string;
+  updatedAt: string | null;
 }
 
 export interface CommentAuthor {
@@ -69,7 +65,7 @@ export interface Comment {
   author: CommentAuthor;
   content: string;
   createdAt: string;
-  updatedAt: string;
+  updatedAt: string | null;
 }
 
 export interface CommentsResponse {


### PR DESCRIPTION
## 📌 PR 제목  
API 응답 구조 변경에 따른 타입 수정 및 평탄화 적용

## ✅ 작업 요약  
- 이슈 상세 API 응답에서 `issues` 키 제거 → `IssueDetailResponse` 객체 자체를 직접 반환하도록 수정  
- `getIssueDetail` 함수에서 `res.json()` 결과를 그대로 반환  
- 댓글 응답은 `comments: Comment[]` 형태 유지하되, `getIssueComments` 함수에서는 `res.comments`만 추출하여 반환  
- `useIssueComments` 훅에서 `useQuery<Comment[]>`로 타입 명시  
- 기존 테스트 코드에서 응답 구조 변경에 따른 접근 방식 수정  

## ✅ 테스트 확인  
- [x] Vitest 기반 테스트에서 응답 데이터 형태 및 필드 접근 정상 확인  
- [x] `CommentList`에서 `data[0].content` 방식으로 댓글 접근 테스트 완료  
- [x] `IssueDetail` 페이지에서 `data.title`, `data.content` 접근 정상 확인  
- [x] 타입 오류 없이 모든 관련 컴포넌트 정상 렌더링  

## 🧠 회고/고민  

- 이슈 상세 응답과 댓글 응답의 구조가 다르게 설계되어 있어, `useQuery`에서 바로 사용할 수 있도록 fetch 함수에서 응답을 평탄화(flatten)해주는 방식이 더 명확하다고 판단했습니다.  
- 실제 컴포넌트에서 사용할 때 `data.title`, `data[0].content` 등 직관적인 접근이 가능하도록 구조를 맞추는 데 집중했습니다.  
- 댓글 응답은 추후 meta 정보가 추가될 가능성을 고려해 현재 API 구조(comments: [])는 유지하면서, 프론트에서는 `res.comments`만 추출하는 절충안을 택했습니다.  
- 타입 정의도 실제 API 응답 형태에 맞춰 정리하여 추후 유지보수와 확장성에 유리하도록 반영했습니다.  

closes #81 