### PR TITLE
[Fix] 댓글 리스트에 평탄화된 응답 구조 적용

### DIFF
--- a/fe/src/features/issue/components/detail/CommentList.tsx
+++ b/fe/src/features/issue/components/detail/CommentList.tsx
@@ -14,7 +14,7 @@ export default function CommentList({ issueId }: CommentListProps) {
 
   return (
     <ul>
-      {data?.comments.map((comment: Comment) => (
+      {data?.map((comment: Comment) => (
         <li key={comment.id}>{comment.content}</li>
       ))}
     </ul>


### PR DESCRIPTION
## 📌 PR 제목

[Fix] 댓글 리스트에 평탄화된 응답 구조 적용

## ✅ 작업 요약

- **댓글 리스트에 평탄화된 응답 적용**: `data.comments.map`에서 `data.map`으로 변경하여 변경된 API 응답 구조에 맞게 수정함

## ✅ 테스트 확인

- [x] 댓글이 정상적으로 렌더링되는지 브라우저에서 수동 확인
- [x] 타입 오류 없이 컴파일 정상 수행

closes #83
