### PR TITLE
[Feature] 이슈 상세 헤더 UI 및 데이터 연동 구현

### DIFF
--- a/fe/src/features/issue/components/detail/IssueHeader.tsx
+++ b/fe/src/features/issue/components/detail/IssueHeader.tsx
@@ -1,3 +1,151 @@
-export default function IssueHeader() {
-  return <div>header</div>;
+import styled from '@emotion/styled';
+import { formatCreatedMessage } from '@/features/issue/utils';
+import ClosedIcon from '@/assets/icons/archive.svg?react';
+import EditIcon from '@/assets/icons/edit.svg?react';
+import AlertCircleIcon from '@/assets/icons/alertCircle.svg?react';
+
+interface IssueHeaderProps {
+  isClosed: boolean;
+  issueNumber: number;
+  title: string;
+  author: {
+    id: number;
+    nickname: string;
+    profileImage: string;
+  };
+  createdAt: string;
+  commentCount: number;
 }
+
+//TODO 편집 기능, 이슈 열림 토글 기능 추가시 prop도 추가
+export default function IssueHeader({
+  isClosed,
+  issueNumber,
+  title,
+  author,
+  createdAt,
+  commentCount,
+}: IssueHeaderProps) {
+  return (
+    <HeaderWrapper>
+      <LeftSection>
+        <Title>
+          {title} <IssueNumber>#{issueNumber}</IssueNumber>
+        </Title>
+        <IssueMetaWrapper>
+          <IsClosedButton>
+            <AlertCircleIcon />
+            <StateBadge>{isClosed ? '닫힌 이슈' : '열린 이슈'}</StateBadge>
+          </IsClosedButton>
+          <MetaInfo>
+            {formatCreatedMessage(createdAt, author.nickname)}
+          </MetaInfo>
+          <CommentCount>코멘트 {commentCount}개</CommentCount>
+        </IssueMetaWrapper>
+      </LeftSection>
+      <RightSection>
+        <StyledButton>
+          <EditIcon />
+          <StyledLabel>제목 편집</StyledLabel>
+        </StyledButton>
+        <StyledButton>
+          <ClosedIcon />
+          <StyledLabel>{isClosed ? '이슈 열기' : '이슈 닫기'}</StyledLabel>
+        </StyledButton>
+      </RightSection>
+    </HeaderWrapper>
+  );
+}
+
+const HeaderWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const LeftSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+const IssueMetaWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+`;
+
+const RightSection = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  height: 48px;
+`;
+
+const Title = styled.h1`
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+
+  color: ${({ theme }) => theme.neutral.text.strong};
+  ${({ theme }) => theme.typography.displayBold32};
+`;
+
+const IssueNumber = styled.span`
+  color: ${({ theme }) => theme.neutral.text.weak};
+`;
+
+const MetaInfo = styled.span`
+  color: ${({ theme }) => theme.neutral.text.weak};
+  ${({ theme }) => theme.typography.displayMedium16};
+`;
+
+const CommentCount = styled.span`
+  margin-left: 24px;
+  color: ${({ theme }) => theme.neutral.text.weak};
+  ${({ theme }) => theme.typography.displayMedium16};
+`;
+
+//TODO 공용 버튼 생성시 StyledButton, IsClosedButton 통합
+const StyledButton = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 128px;
+  height: 40px;
+  padding: 12px 0;
+  border: 1px solid ${({ theme }) => theme.palette.blue};
+  border-radius: ${({ theme }) => theme.radius.medium};
+  color: ${({ theme }) => theme.palette.blue};
+  ${({ theme }) => theme.typography.availableMedium12};
+
+  cursor: pointer;
+`;
+
+const StyledLabel = styled.span`
+  padding: 0 4px;
+  ${({ theme }) => theme.typography.availableMedium12};
+`;
+
+const IsClosedButton = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 8px 16px;
+  background-color: ${({ theme }) => theme.palette.blue};
+  border-radius: ${({ theme }) => theme.radius.large};
+  color: ${({ theme }) => theme.brand.text.default};
+
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    opacity: 0.8;
+  }
+`;
+
+const StateBadge = styled.span`
+  padding: 0 4px;
+  color: ${({ theme }) => theme.brand.text.default};
+  ${({ theme }) => theme.typography.displayMedium12};
+`;

--- a/fe/src/pages/IssueDetailPage.tsx
+++ b/fe/src/pages/IssueDetailPage.tsx
@@ -29,10 +29,16 @@ export default function IssueDetailPage() {
   // TODO 로딩,에러 상태에 따라 분기처리 내부적으로 처리
   if (isIssueDetailLoading) return <div>로딩 중...</div>;
   if (isIssueDetailError) return <div>에러 발생</div>;
+  if (!issueDetailData) return;
 
   return (
     <VerticalStack>
-      <IssueHeader />
+      <IssueHeader
+        {...issueDetailData}
+        issueNumber={issueDetailData.id}
+        // TODO useIssueComments 호출위치를 현재 파일로 변경 후 랜더링 반영
+        commentCount={0}
+      />
       <Divider />
       <MainArea>
         <IssueMainSection issueId={issueId} />


### PR DESCRIPTION
## 📌 PR 제목

이슈 상세 헤더 UI 및 데이터 연동 구현

## ✅ 작업 요약

- **IssueHeader 컴포넌트 생성**: 이슈 상세 상단 헤더 영역 전반 구현
- **타이틀, 상태 뱃지, 작성자, 생성일 렌더링**: 피그마 스타일 기준으로 정렬 및 스타일링
- **데이터 연동**: 기존에 작성된 `useIssueDetail` 훅을 연결하여 API 응답값을 표시
- **Fallback 처리 추가**: `issueDetailData`가 없을 경우 분기 처리로 비정상 렌더링 방지
- **코멘트 수는 현재 하드코딩으로 처리 중** → 이후 `useIssueComments` 훅 이동 및 commentCount 연동 예정 (#86)

## ✅ 테스트 확인

- [x] 페이지 진입 시 헤더 UI 정상 렌더링 확인
- [x] 상태(open/closed) 뱃지가 조건에 맞게 표시되는지 확인
- [x] 작성자 및 생성일이 API 응답과 일치하는지 확인
- [x] `issueDetailData`가 undefined일 때 안전하게 fallback 처리되는지 확인

## 🔗 관련 이슈

closes #52  
relates to #86