### PR TITLE
[Refactor] 이슈 상세 페이지 댓글 수 헤더 연동 및 로딩/에러 상태 상위 처리

### DIFF
--- a/fe/src/features/issue/components/detail/CommentList.tsx
+++ b/fe/src/features/issue/components/detail/CommentList.tsx
@@ -1,20 +1,22 @@
-import useIssueComments from '../../hooks/useIssueComments';
 import { type Comment } from '../../types/issue';
 
 interface CommentListProps {
-  issueId: number;
+  isLoading: boolean;
+  isError: boolean;
+  comments: Comment[];
 }
 
-export default function CommentList({ issueId }: CommentListProps) {
-  const { data, isLoading, isError } = useIssueComments(issueId);
-
-  //TODO 에러나 로딩에 따른 구체적인 분기처리 필요
-  if (isLoading) return <div>로딩 중...</div>;
-  if (isError) return <div>댓글 불러오기 실패</div>;
+export default function CommentList({
+  comments,
+  isError,
+  isLoading,
+}: CommentListProps) {
+  if (isLoading) return <div>댓글 로딩 중...</div>;
+  if (isError) return <div>댓글을 불러오는 데 실패했습니다.</div>;
 
   return (
     <ul>
-      {data?.map((comment: Comment) => (
+      {comments.map((comment: Comment) => (
         <li key={comment.id}>{comment.content}</li>
       ))}
     </ul>

--- a/fe/src/features/issue/components/detail/CommentList.tsx
+++ b/fe/src/features/issue/components/detail/CommentList.tsx
@@ -1,19 +1,10 @@
 import { type Comment } from '../../types/issue';
 
 interface CommentListProps {
-  isLoading: boolean;
-  isError: boolean;
   comments: Comment[];
 }
 
-export default function CommentList({
-  comments,
-  isError,
-  isLoading,
-}: CommentListProps) {
-  if (isLoading) return <div>댓글 로딩 중...</div>;
-  if (isError) return <div>댓글을 불러오는 데 실패했습니다.</div>;
-
+export default function CommentList({ comments }: CommentListProps) {
   return (
     <ul>
       {comments.map((comment: Comment) => (

--- a/fe/src/features/issue/components/detail/IssueMainSection.tsx
+++ b/fe/src/features/issue/components/detail/IssueMainSection.tsx
@@ -5,24 +5,14 @@ import CommentList from './CommentList';
 import CommentEditor from './CommentEditor';
 
 interface IssueMainSectionProps {
-  isLoading: boolean;
-  isError: boolean;
   comments: Comment[];
 }
 
-export default function IssueMainSection({
-  comments,
-  isLoading,
-  isError,
-}: IssueMainSectionProps) {
+export default function IssueMainSection({ comments }: IssueMainSectionProps) {
   return (
     <MainWrapper>
       <IssueContent />
-      <CommentList
-        comments={comments}
-        isLoading={isLoading}
-        isError={isError}
-      />
+      <CommentList comments={comments} />
       <CommentEditor />
     </MainWrapper>
   );

--- a/fe/src/features/issue/components/detail/IssueMainSection.tsx
+++ b/fe/src/features/issue/components/detail/IssueMainSection.tsx
@@ -1,17 +1,28 @@
 import styled from '@emotion/styled';
+import { type Comment } from '../../types/issue';
 import IssueContent from './IssueContent';
 import CommentList from './CommentList';
 import CommentEditor from './CommentEditor';
 
 interface IssueMainSectionProps {
-  issueId: number;
+  isLoading: boolean;
+  isError: boolean;
+  comments: Comment[];
 }
 
-export default function IssueMainSection({ issueId }: IssueMainSectionProps) {
+export default function IssueMainSection({
+  comments,
+  isLoading,
+  isError,
+}: IssueMainSectionProps) {
   return (
     <MainWrapper>
       <IssueContent />
-      <CommentList issueId={issueId} />
+      <CommentList
+        comments={comments}
+        isLoading={isLoading}
+        isError={isError}
+      />
       <CommentEditor />
     </MainWrapper>
   );

--- a/fe/src/pages/IssueDetailPage.tsx
+++ b/fe/src/pages/IssueDetailPage.tsx
@@ -34,9 +34,10 @@ export default function IssueDetailPage() {
   }, [isIssueDetailError]);
 
   // TODO 로딩,에러 상태에 따라 분기처리 내부적으로 처리
-  if (isIssueDetailLoading) return <div>로딩 중...</div>;
-  if (isIssueDetailError) return <div>에러 발생</div>;
-  if (!issueDetailData) return;
+  if (isIssueDetailLoading || isCommentLoading) return <div>로딩 중...</div>;
+
+  if (isIssueDetailError || isCommentError) return <div>에러 발생</div>;
+  if (!issueDetailData || !commentData) return;
 
   return (
     <VerticalStack>
@@ -47,11 +48,7 @@ export default function IssueDetailPage() {
       />
       <Divider />
       <MainArea>
-        <IssueMainSection
-          comments={commentData ?? []}
-          isLoading={isCommentLoading}
-          isError={isCommentError}
-        />
+        <IssueMainSection comments={commentData ?? []} />
         <Sidebar />
       </MainArea>
     </VerticalStack>

--- a/fe/src/pages/IssueDetailPage.tsx
+++ b/fe/src/pages/IssueDetailPage.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import styled from '@emotion/styled';
 import useIssueDetail from '@/features/issue/hooks/useIssueDetail';
+import useIssueComments from '@/features/issue/hooks/useIssueComments';
 import Divider from '@/shared/components/Divider';
 import IssueHeader from '@/features/issue/components/detail/IssueHeader';
 import IssueMainSection from '@/features/issue/components/detail/IssueMainSection';
@@ -18,6 +19,12 @@ export default function IssueDetailPage() {
     isLoading: isIssueDetailLoading,
     isError: isIssueDetailError,
   } = useIssueDetail(issueId);
+
+  const {
+    data: commentData,
+    isLoading: isCommentLoading,
+    isError: isCommentError,
+  } = useIssueComments(issueId);
 
   //TODO 에러 종류에 따라 분기 처리
   useEffect(() => {
@@ -36,12 +43,15 @@ export default function IssueDetailPage() {
       <IssueHeader
         {...issueDetailData}
         issueNumber={issueDetailData.id}
-        // TODO useIssueComments 호출위치를 현재 파일로 변경 후 랜더링 반영
-        commentCount={0}
+        commentCount={commentData?.length ?? 0}
       />
       <Divider />
       <MainArea>
-        <IssueMainSection issueId={issueId} />
+        <IssueMainSection
+          comments={commentData ?? []}
+          isLoading={isCommentLoading}
+          isError={isCommentError}
+        />
         <Sidebar />
       </MainArea>
     </VerticalStack>


### PR DESCRIPTION
## 📌 PR 제목
이슈 상세 페이지 댓글 수 헤더 연동 및 로딩/에러 상태 상위 처리

## ✅ 작업 요약

- **useIssueComments 훅을 상위로 이동**  
  기존에 IssueMainSection 내부에서만 호출되던 댓글 훅을 IssueDetailPage로 이동하여 데이터 흐름을 일관되게 구성함  
  → `refactor(issue): lift useIssueComments to page level`

- **헤더에 commentCount 전달**  
  댓글 수를 계산하여 IssueHeader로 props로 전달 (`comments?.length ?? 0` 형태로 방어적 처리)

- **로딩/에러 상태 상위 분기 처리**  
  이슈 상세 데이터와 댓글 데이터의 로딩/에러 상태를 하위가 아닌 최상위 컴포넌트에서 일괄 처리하도록 리팩토링  
  → `refactor(issue): handle loading and error states at top level`

## ✅ 테스트 확인

- [x] 댓글 수가 Header에 정상적으로 표시되는지 확인
- [x] 댓글 데이터 미존재 시 0으로 표시되는지 확인
- [x] 로딩/에러 발생 시 에러 컴포넌트가 정상적으로 출력되는지 확인
- [x] IssueMainSection, CommentList의 기존 동작이 유지되는지 확인

## 🧠 회고/고민

### 1. **댓글 수 데이터 흐름을 어떻게 일관되게 만들까?**

#### 🧐 고민의 배경

- 기존에는 댓글 수가 필요한 컴포넌트가 헤더와 본문으로 나뉘어 있음에도, useIssueComments 훅이 IssueMainSection 내부에 있어, Header에서 직접 접근할 수 없었습니다.
- 이를 해결하기 위해 댓글 데이터를 최상위에서 관리하고, 하위로 내려주는 방식으로 전환할 필요가 있었습니다.

#### ✅ 최종 해결

- `useIssueComments`를 `IssueDetailPage`로 끌어올려 최상위에서 데이터 흐름을 통제하도록 했습니다.
- `commentCount`를 Header 컴포넌트로 명시적으로 넘겨주면서, 필요 데이터를 정확하게 분리해 전달했습니다.
- 로딩/에러 상태 역시 각 컴포넌트에서 개별적으로 처리하던 방식에서, 페이지 레벨에서 한꺼번에 처리하는 방식으로 통일하여, 전체적인 UI 흐름을 더 예측 가능하게 만들었습니다.

closes #86 