### PR TITLE
[Feature] 이슈 상세 댓글 리스트 렌더링 및 UI 구성

### DIFF
--- a/fe/src/features/issue/components/detail/CommentDescription.tsx
+++ b/fe/src/features/issue/components/detail/CommentDescription.tsx
@@ -1,5 +1,5 @@
 import DescriptionBox, { type DescriptionBoxProps } from './DescriptionBox';
 
-export default function IssueDescription(props: DescriptionBoxProps) {
+export default function CommentDescription(props: DescriptionBoxProps) {
   return <DescriptionBox {...props} />;
 }

--- a/fe/src/features/issue/components/detail/CommentList.tsx
+++ b/fe/src/features/issue/components/detail/CommentList.tsx
@@ -1,4 +1,6 @@
+import styled from '@emotion/styled';
 import { type Comment } from '../../types/issue';
+import CommentDescription from './CommentDescription';
 
 interface CommentListProps {
   comments: Comment[];
@@ -6,10 +8,21 @@ interface CommentListProps {
 
 export default function CommentList({ comments }: CommentListProps) {
   return (
-    <ul>
+    <Wrapper>
       {comments.map((comment: Comment) => (
-        <li key={comment.id}>{comment.content}</li>
+        <CommentDescription
+          key={comment.id}
+          content={comment.content}
+          author={comment.author}
+          createdAt={comment.createdAt}
+        />
       ))}
-    </ul>
+    </Wrapper>
   );
 }
+
+const Wrapper = styled.ul`
+  display: flex;
+  gap: 24px;
+  flex-direction: column;
+`;

--- a/fe/src/features/issue/components/detail/DescriptionBox.tsx
+++ b/fe/src/features/issue/components/detail/DescriptionBox.tsx
@@ -1,0 +1,36 @@
+import styled from '@emotion/styled';
+import { type CommentAuthor } from '../../types/issue';
+import DescriptionHeader from './DescriptionHeader';
+import DescriptionBody from './DescriptionBody';
+
+export interface DescriptionBoxProps {
+  content: string;
+  author: CommentAuthor;
+  createdAt: string;
+}
+
+export default function DescriptionBox({
+  content,
+  author,
+  createdAt,
+}: DescriptionBoxProps) {
+  return (
+    <Wrapper>
+      <DescriptionHeader
+        profileImageUrl={author.profileImage}
+        nickname={author.nickname}
+        createdAt={createdAt}
+        isAuthor={true} //TODO 로그인 기능 구현시 변경
+      />
+      <DescriptionBody content={content} />
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  border-radius: ${({ theme }) => theme.radius.large};
+  border: 1px solid ${({ theme }) => theme.neutral.border.default};
+  overflow: hidden;
+`;

--- a/fe/src/features/issue/components/detail/IssueMainSection.tsx
+++ b/fe/src/features/issue/components/detail/IssueMainSection.tsx
@@ -24,7 +24,7 @@ export default function IssueMainSection({
         createdAt={createdAt}
         author={author}
       />
-      <CommentList comments={comments} />
+      {comments.length > 0 && <CommentList comments={comments} />}
       <CommentEditor />
     </MainWrapper>
   );


### PR DESCRIPTION
## 📌 PR 제목

[Feature] 댓글 리스트 렌더링 및 UI 구성

## ✅ 작업 요약

- [x] useIssueComments 훅으로 받아온 데이터를 기반으로 댓글 리스트 렌더링
- [x] CommentList 컴포넌트 생성
- [x] CommentDescription 컴포넌트 생성 (작성자, 날짜, 내용 구성)
- [x] 댓글이 없을 경우 Wrapper 자체 렌더링 방지
- [x] 로딩 / 에러 상태에 따른 fallback 처리
```
  if (isIssueDetailLoading || isCommentLoading) return <div>로딩 중...</div>;

  if (isIssueDetailError || isCommentError) return <div>에러 발생</div>;
```

> fallback UI 구성은 추후 리팩토링 이슈로 처리 예정   
relate #95 

- [x] 이슈 본문과 댓글 UI의 구조적 유사성을 고려하여 공통 컴포넌트 `DescriptionBox`를 생성하고, 이를 기반으로 `IssueDescription`, `CommentDescription` 각각 정의하여 역할 분리

## ✅ 테스트 확인

- [x] 댓글 데이터가 정상적으로 화면에 표시됨
- [x] 각 댓글 항목에 작성자, 날짜, 내용이 정확히 렌더링됨
- [x] 댓글이 없을 때 빈 UI가 출력되지 않음
- [x] 로딩/에러 상태에 따른 분기 처리 정상 동작

## 🧠 회고/고민

### 1. 댓글이 없을 경우 어떻게 처리할까?

#### 고민의 배경
- 댓글이 없을 때 빈 리스트를 렌더링하면 사용자에게 “버그인가?”라는 혼란을 줄 수 있음.
- 단순히 “댓글이 없습니다”를 보여줄지, 아예 컴포넌트를 숨길지 판단이 필요했음.

#### 결정 및 처리
- 해당 섹션의 레이아웃상 댓글이 없을 때는 빈 영역조차 나타나지 않도록 처리함.
- 추후 별도의 안내 문구가 필요할 경우, 이 부분만 조건부로 쉽게 추가할 수 있도록 분리 구조를 유지함.

### 2. 공통 컴포넌트 구조 설계: DescriptionBox 재사용 전략

#### 고민의 배경
- 이슈 본문과 댓글 UI 모두 작성자, 생성일, 마크다운 기반 내용 등 구조가 매우 유사했음.
- 하나의 공통 컴포넌트를 import하여 그대로 사용하는 방식과, 각 도메인에 맞는 래퍼 컴포넌트를 따로 생성하는 방식 사이에서 고민함.

#### 결정 및 처리
- 의미 있는 컴포넌트 네이밍과 역할 분리를 위해, 공통 컴포넌트인 `DescriptionBox`를 기반으로 `IssueDescription`, `CommentDescription`이라는 별도의 래퍼 컴포넌트를 각각 생성함.
- 동일한 UI 구조를 공유하되 각 컴포넌트의 역할이 명확히 드러나도록 하여, 코드의 의도를 직관적으로 이해할 수 있게 했고, 향후 유지보수 및 확장에도 유리한 구조로 설계함.

closes #51 
relates #54