### PR TITLE
[Refactor] content prop 타입을 string | null로 변경

### DIFF
--- a/fe/src/features/issue/components/detail/DescriptionBox.tsx
+++ b/fe/src/features/issue/components/detail/DescriptionBox.tsx
@@ -4,7 +4,7 @@ import DescriptionHeader from './DescriptionHeader';
 import DescriptionBody from './DescriptionBody';
 
 export interface DescriptionBoxProps {
-  content: string;
+  content: string | null;
   author: CommentAuthor;
   createdAt: string;
 }

--- a/fe/src/features/issue/components/detail/IssueMainSection.tsx
+++ b/fe/src/features/issue/components/detail/IssueMainSection.tsx
@@ -6,7 +6,7 @@ import CommentEditor from './CommentEditor';
 
 interface IssueMainSectionProps {
   comments: Comment[];
-  content: string;
+  content: string | null;
   createdAt: string;
   author: CommentAuthor;
 }


### PR DESCRIPTION
## 📌 PR 제목

[Refactor] content prop 타입을 string | null로 변경

## ✅ 작업 요약

- `DescriptionBox`와 `IssueMainSection` 컴포넌트의 `content` prop 타입을 `string`에서 `string | null`로 변경  
- 실제 API 응답에서 `null`이 포함될 수 있는 상황을 반영하여 타입 안정성 확보  
- `null` 타입이 올 경우 TypeScript 오류를 방지하고, 컴포넌트의 일관된 동작을 유도

## ✅ 테스트 확인

- [x] `content`가 `null`일 경우에도 컴포넌트가 정상 렌더링됨
- [x] 기존 string 타입의 데이터도 정상 렌더링됨
- [x] 타입스크립트 에러 없이 빌드 성공

## 🧠 회고/고민

- `content`에 `null`이 들어오면서 TypeScript 오류가 발생했지만, 실제 화면은 정상적으로 렌더링되는 상황이 발생함
- 이 과정에서 "왜 타입 오류가 나는데도 브라우저에서 문제없이 동작하지?"라는 의문을 가졌고,  
  이를 통해 TypeScript는 **트랜스파일 시점에서의 정적 분석 도구**이며, 실제 런타임에는 영향이 없다는 점을 이해하게 되었음
- 결국 TypeScript 오류는 개발자의 실수를 방지하고 코드 품질을 높이기 위한 것으로,  
  타입 선언이 실제 데이터 구조와 정확히 일치하도록 하는 것이 중요하다는 점을 다시 한 번 느꼈음

## 🔗 참고 자료

- [TypeScript Handbook - Union Types](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types)

closes #98