### PR TITLE
[Feature] IssueSidebar - 담당자, 레이블, 마일스톤 섹션 UI 구현

### DIFF
--- a/fe/src/features/issue/components/IssueSidebar.tsx
+++ b/fe/src/features/issue/components/IssueSidebar.tsx
@@ -1,0 +1,139 @@
+import styled from '@emotion/styled';
+import { getAccessibleLabelStyle } from '@/shared/utils/color';
+import { type Assignee, type Milestone, type Label } from '../types/issue';
+import SidebarSection from './SidebarSection';
+import MilestoneProgressBar from '@/shared/components/MilestoneProgressBar';
+
+interface SidebarProps {
+  assignees: Assignee[];
+  labels: Label[];
+  milestone: Milestone | null;
+}
+
+export default function IssueSidebar({
+  assignees,
+  labels,
+  milestone,
+}: SidebarProps) {
+  return (
+    <SidebarWrapper>
+      <SidebarSection title="담당자">
+        {assignees.length > 0 && (
+          <SectionList>
+            {assignees.map(assignee => (
+              <AssigneeWrapper key={assignee.id}>
+                <ProfileImage src={assignee.profileImage} alt="프로필 이미지" />
+                <Nickname>{assignee.nickname}</Nickname>
+              </AssigneeWrapper>
+            ))}
+          </SectionList>
+        )}
+      </SidebarSection>
+
+      <SidebarSection title="레이블">
+        {labels.length > 0 && <LabelList>{renderLabelList(labels)}</LabelList>}
+      </SidebarSection>
+
+      <SidebarSection title="마일스톤">
+        {milestone && (
+          <MilestoneProgressBar percentage={milestone?.progressRate}>
+            <MalestoneLabel>{milestone.name}</MalestoneLabel>
+          </MilestoneProgressBar>
+        )}
+      </SidebarSection>
+    </SidebarWrapper>
+  );
+}
+
+const SidebarWrapper = styled.div`
+  width: 288px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  border-radius: ${({ theme }) => theme.radius.medium};
+  border: 1px solid ${({ theme }) => theme.neutral.border.default};
+  background-color: ${({ theme }) => theme.neutral.surface.strong};
+
+  overflow: hidden;
+
+  & > *:not(:last-child) {
+    border-bottom: 1px solid ${({ theme }) => theme.neutral.border.default};
+  }
+`;
+
+const LabelList = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 4px;
+
+  ${({ theme }) => theme.typography.availableMedium12};
+  color: ${({ theme }) => theme.neutral.text.strong};
+`;
+
+const SectionList = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  ${({ theme }) => theme.typography.availableMedium12};
+  color: ${({ theme }) => theme.neutral.text.strong};
+`;
+
+// TODO profile 공통 컴포넌트 분리
+const ProfileImage = styled.img`
+  width: 20px;
+  height: 19px;
+  border-radius: ${({ theme }) => theme.radius.half};
+`;
+
+const Nickname = styled.span`
+  ${({ theme }) => theme.typography.displayMedium16};
+  color: ${({ theme }) => theme.neutral.text.default};
+`;
+
+const AssigneeWrapper = styled.div`
+  display: flex;
+  gap: 8px;
+  align-items: center;
+`;
+
+const MalestoneLabel = styled.span`
+  ${({ theme }) => theme.typography.displayMedium12};
+  color: ${({ theme }) => theme.neutral.text.strong};
+`;
+
+//TODO 공용 라벨 컴포넌트 분리
+interface LabelTagProps {
+  backgroundColor: string;
+  borderColor: string;
+  color: string;
+}
+
+const LabelTag = styled.span<LabelTagProps>`
+  padding: 4px 9px;
+  border-radius: ${({ theme }) => theme.radius.medium};
+  color: ${({ color }) => color};
+  background-color: ${({ backgroundColor }) => backgroundColor};
+  border: 1px solid ${({ borderColor }) => borderColor};
+  ${({ theme }) => theme.typography.displayMedium12};
+`;
+
+//TODO 공용 분리
+function renderLabelList(labels: Label[]) {
+  return labels.map(label => {
+    const { textColor, borderColor } = getAccessibleLabelStyle(label.color);
+    return (
+      <LabelTag
+        key={label.id}
+        backgroundColor={label.color}
+        borderColor={borderColor}
+        color={textColor}
+      >
+        {label.name}
+      </LabelTag>
+    );
+  });
+}

--- a/fe/src/features/issue/components/IssueSidebar.tsx
+++ b/fe/src/features/issue/components/IssueSidebar.tsx
@@ -17,27 +17,25 @@ export default function IssueSidebar({
 }: SidebarProps) {
   return (
     <SidebarWrapper>
-      <SidebarSection title="담당자">
-        {assignees.length > 0 && (
-          <SectionList>
-            {assignees.map(assignee => (
-              <AssigneeWrapper key={assignee.id}>
-                <ProfileImage src={assignee.profileImage} alt="프로필 이미지" />
-                <Nickname>{assignee.nickname}</Nickname>
-              </AssigneeWrapper>
-            ))}
-          </SectionList>
-        )}
+      <SidebarSection title="담당자" isEmpty={assignees.length === 0}>
+        <SectionList>
+          {assignees.map(assignee => (
+            <AssigneeWrapper key={assignee.id}>
+              <ProfileImage src={assignee.profileImage} alt="프로필 이미지" />
+              <Nickname>{assignee.nickname}</Nickname>
+            </AssigneeWrapper>
+          ))}
+        </SectionList>
       </SidebarSection>
 
-      <SidebarSection title="레이블">
-        {labels.length > 0 && <LabelList>{renderLabelList(labels)}</LabelList>}
+      <SidebarSection title="레이블" isEmpty={assignees.length === 0}>
+        <LabelList>{renderLabelList(labels)}</LabelList>
       </SidebarSection>
 
-      <SidebarSection title="마일스톤">
+      <SidebarSection title="마일스톤" isEmpty={!milestone}>
         {milestone && (
-          <MilestoneProgressBar percentage={milestone?.progressRate}>
-            <MalestoneLabel>{milestone.name}</MalestoneLabel>
+          <MilestoneProgressBar percentage={milestone.progressRate}>
+            <MilestoneLabel>{milestone.name}</MilestoneLabel>
           </MilestoneProgressBar>
         )}
       </SidebarSection>
@@ -100,7 +98,7 @@ const AssigneeWrapper = styled.div`
   align-items: center;
 `;
 
-const MalestoneLabel = styled.span`
+const MilestoneLabel = styled.span`
   ${({ theme }) => theme.typography.displayMedium12};
   color: ${({ theme }) => theme.neutral.text.strong};
 `;

--- a/fe/src/features/issue/components/Sidebar.tsx
+++ b/fe/src/features/issue/components/Sidebar.tsx
@@ -1,3 +1,0 @@
-export default function Sidebar() {
-  return <div>sidebar</div>;
-}

--- a/fe/src/features/issue/components/SidebarSection.tsx
+++ b/fe/src/features/issue/components/SidebarSection.tsx
@@ -5,11 +5,13 @@ import { type ReactNode } from 'react';
 interface SidebarSectionProps {
   title: string;
   children: ReactNode;
+  isEmpty: boolean;
 }
 
 export default function SidebarSection({
   title,
   children,
+  isEmpty,
 }: SidebarSectionProps) {
   return (
     <Section>
@@ -17,7 +19,7 @@ export default function SidebarSection({
         {title}
         <PlusIcon />
       </SectionHeader>
-      {children}
+      {!isEmpty && children}
     </Section>
   );
 }

--- a/fe/src/features/issue/components/SidebarSection.tsx
+++ b/fe/src/features/issue/components/SidebarSection.tsx
@@ -1,0 +1,38 @@
+import styled from '@emotion/styled';
+import PlusIcon from '@/assets/icons/plus.svg?react';
+import { type ReactNode } from 'react';
+
+interface SidebarSectionProps {
+  title: string;
+  children: ReactNode;
+}
+
+export default function SidebarSection({
+  title,
+  children,
+}: SidebarSectionProps) {
+  return (
+    <Section>
+      <SectionHeader>
+        {title}
+        <PlusIcon />
+      </SectionHeader>
+      {children}
+    </Section>
+  );
+}
+
+const Section = styled.div<{ noDivider?: boolean }>`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 32px;
+`;
+
+const SectionHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  gap: 4px;
+  ${({ theme }) => theme.typography.availableMedium16};
+  color: ${({ theme }) => theme.neutral.text.default};
+`;

--- a/fe/src/pages/IssueDetailPage.tsx
+++ b/fe/src/pages/IssueDetailPage.tsx
@@ -1,12 +1,13 @@
 import { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import styled from '@emotion/styled';
+import TrashIcon from '@/assets/icons/trash.svg?react';
 import useIssueDetail from '@/features/issue/hooks/useIssueDetail';
 import useIssueComments from '@/features/issue/hooks/useIssueComments';
 import Divider from '@/shared/components/Divider';
 import IssueHeader from '@/features/issue/components/detail/IssueHeader';
 import IssueMainSection from '@/features/issue/components/detail/IssueMainSection';
-import Sidebar from '@/features/issue/components/Sidebar';
+import IssueSidebar from '@/features/issue/components/IssueSidebar';
 import VerticalStack from '@/layouts/VerticalStack';
 
 export default function IssueDetailPage() {
@@ -54,7 +55,14 @@ export default function IssueDetailPage() {
           createdAt={issueDetailData.createdAt}
           author={issueDetailData.author}
         />
-        <Sidebar />
+        <SideSection>
+          <IssueSidebar
+            assignees={issueDetailData.assignees}
+            labels={issueDetailData.labels}
+            milestone={issueDetailData.milestone}
+          />
+          <TabItem icon={<TrashIcon />} label="이슈 삭제" />
+        </SideSection>
       </MainArea>
     </VerticalStack>
   );
@@ -62,5 +70,59 @@ export default function IssueDetailPage() {
 
 const MainArea = styled.div`
   display: flex;
+  align-items: flex-start;
   gap: 32px;
+`;
+
+const SideSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 16px;
+`;
+
+interface TabItemProps {
+  icon: React.ReactNode;
+  label: string;
+}
+
+// TODO 공용으로 분리 및 onClick 추가
+function TabItem({ icon, label }: TabItemProps) {
+  return (
+    <TabButton>
+      <IconWrapper>{icon}</IconWrapper>
+      <Label>{label}</Label>
+    </TabButton>
+  );
+}
+
+const TabButton = styled.button<{ active?: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 0;
+  margin-right: 16px;
+  color: ${({ theme }) => theme.danger.text.default};
+  ${({ theme }) => theme.typography.availableMedium12};
+
+  cursor: pointer;
+
+  &:hover {
+    opacity: 0.8;
+  }
+`;
+
+const IconWrapper = styled.span`
+  display: flex;
+  align-items: center;
+  color: inherit;
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
+`;
+
+const Label = styled.span`
+  color: inherit;
 `;

--- a/fe/src/shared/components/MilestoneProgressBar.tsx
+++ b/fe/src/shared/components/MilestoneProgressBar.tsx
@@ -1,0 +1,53 @@
+import styled from '@emotion/styled';
+import { type ReactNode } from 'react';
+
+interface MilestoneProgressBarProps {
+  percentage: number;
+  height?: number;
+  children?: ReactNode;
+}
+
+const MilestoneProgressBar = ({
+  percentage,
+  height = 8,
+  children,
+}: MilestoneProgressBarProps) => {
+  return (
+    <Wrapper>
+      <Track height={height}>
+        <Fill width={percentage} />
+      </Track>
+      {children && <ContentWrapper>{children}</ContentWrapper>}
+    </Wrapper>
+  );
+};
+
+export default MilestoneProgressBar;
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const Track = styled.div<{ height: number }>`
+  width: 100%;
+  height: ${({ height }) => height}px;
+  background-color: ${({ theme }) => theme.neutral.surface.bold};
+  border-radius: 4px;
+  overflow: hidden;
+`;
+
+const Fill = styled.div<{ width: number }>`
+  width: ${({ width }) => width}%;
+  height: 100%;
+  background-color: ${({ theme }) => theme.palette.blue};
+  transition: width 0.3s ease;
+`;
+
+const ContentWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  ${({ theme }) => theme.typography.availableMedium12};
+  color: ${({ theme }) => theme.neutral.text.weak};
+`;


### PR DESCRIPTION
## 📌 PR 제목

[Feature] IssueSidebar - 담당자, 레이블, 마일스톤 섹션 UI 구현

## ✅ 작업 요약

- [x] 사이드바 영역에 담당자, 레이블, 마일스톤 정보를 표시하는 `IssueSidebar` 컴포넌트 구현
- [x] 재사용 가능한 `SidebarSection` 컴포넌트 생성 (title, isEmpty, children props 지원)
- [x] 각 섹션에 대해 API 응답값을 받아 적절한 UI 구성
- [x] 값이 없는 경우 children을 렌더링하지 않고 `+` 버튼만 노출되도록 조건부 렌더링 처리

### UI 화면
<img width="1487" alt="스크린샷 2025-05-22 오후 6 32 12" src="https://github.com/user-attachments/assets/b114d837-c40d-4319-9365-ad5427afce1c" />
<img width="1496" alt="스크린샷 2025-05-22 오후 6 25 08" src="https://github.com/user-attachments/assets/c34318d3-d6a5-46c4-bef7-18dac757e2b5" />


## ✅ 테스트 확인

- [x] 담당자, 레이블, 마일스톤 데이터가 정확하게 UI에 표시됨
- [x] 각 값이 없을 경우 `+` 버튼만 표시되고 빈 영역은 렌더링되지 않음
- [x] 사이드바 UI가 피그마 디자인 기준에 맞게 구성됨
- [x] 각 섹션이 명확히 구분되어 표시됨

## 🧠 회고/고민

### 1. 사이드바 구성을 어떻게 더 유연하게 만들 수 있을까?

#### 고민의 배경
- 사이드바에서 담당자, 레이블, 마일스톤 각각의 UI가 반복 구조를 갖고 있었음.
- 조건부 렌더링을 위해 `assignees.length > 0`과 같은 체크를 각 섹션마다 직접 수행하던 방식은 반복적이고, 추후 유지보수 시 실수 가능성이 있었음.

#### 결정 및 처리


- `SidebarSection`이라는 공통 컴포넌트를 만들고, `title`, `isEmpty`, `children`만 전달하면 각 섹션을 쉽게 재구성할 수 있도록 구조화함.
- 반복되는 조건부 렌더링 로직을 `OptionalSection` 컴포넌트로 추상화하여, 데이터가 없을 경우 `null`을 반환하게 하고, children이 있을 경우에만 섹션을 렌더링하도록 함.
- 이를 통해 코드의 가독성과 재사용성이 크게 향상되었으며, 추후 드롭다운 기능 확장 시에도 해당 구조를 유지한 채로 일관된 방식으로 적용 가능하도록 대비함.

closes #53 