### PR TITLE
[Feature] Header - 로고 클릭 시 홈 화면으로 라우팅 기능 추가

### DIFF
--- a/fe/src/shared/components/Header.tsx
+++ b/fe/src/shared/components/Header.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { Link } from 'react-router-dom';
 import Logo from '@/assets/logoMedium.svg?react';
 import DarkModeToggle from './DarkModeToggle';
 
@@ -6,7 +7,9 @@ export default function Header() {
   return (
     <Wrapper>
       <LeftSection>
-        <StyledLogo />
+        <Link to="/">
+          <StyledLogo />
+        </Link>
         <DarkModeToggle />
       </LeftSection>
       <Profile profileImageUrl="/images/sampleProfile.png" />


### PR DESCRIPTION
## 📌 PR 제목

[Feature] Header - 로고 클릭 시 홈 화면으로 라우팅 기능 추가

## ✅ 작업 요약

- [x] 사용자가 헤더의 로고를 클릭하면 이슈 목록 화면(`/`)으로 이동하도록 라우팅 기능 추가
- [x] React Router의 `Link` 컴포넌트를 활용해 SPA 방식으로 전환 처리
- [x] 직관적인 UX를 위해 메인으로 빠르게 돌아갈 수 있는 진입 경로 제공

## ✅ 테스트 확인

- [x] 로고 클릭 시 주소창이 `/`로 변경되고 메인 화면으로 이동함
- [x] 새로고침 없이 SPA 방식으로 정상 작동 확인
- [x] 수동 테스트를 통해 라우팅 동작 문제 없음 확인

## 🧠 회고/고민

### 1. `useNavigate` vs `Link` 선택의 고민

#### 고민의 배경
- 라우팅 처리 방식으로 `useNavigate`와 `Link` 중 어떤 것을 선택할지 고민이 있었음
- `useNavigate`는 클릭 이벤트 핸들러 내부에서 명시적으로 호출해야 하고, `Link`는 선언적으로 처리 가능하다는 차이점이 있음.

#### 결정 및 처리
- 로고 클릭은 단순한 경로 이동이므로 클릭 이벤트로 처리할 필요 없이 `Link`로 감싸는 방식이 더 명확하고 유지보수에도 용이하다고 판단함.
- 따라서 `Link`를 사용해 더 간단하고 직관적인 라우팅 구현을 선택함.

closes #96 