### PR TITLE
[Refactor] Profile - 공용 컴포넌트 생성 및 전역 적용

### DIFF
--- a/fe/src/features/issue/components/IssueSidebar.tsx
+++ b/fe/src/features/issue/components/IssueSidebar.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { getAccessibleLabelStyle } from '@/shared/utils/color';
+import Profile from '@/shared/components/Profile';
 import { type Assignee, type Milestone, type Label } from '../types/issue';
 import SidebarSection from './SidebarSection';
 import MilestoneProgressBar from '@/shared/components/MilestoneProgressBar';
@@ -20,10 +21,12 @@ export default function IssueSidebar({
       <SidebarSection title="담당자" isEmpty={assignees.length === 0}>
         <SectionList>
           {assignees.map(assignee => (
-            <AssigneeWrapper key={assignee.id}>
-              <ProfileImage src={assignee.profileImage} alt="프로필 이미지" />
-              <Nickname>{assignee.nickname}</Nickname>
-            </AssigneeWrapper>
+            <Profile
+              key={assignee.id}
+              size="sm"
+              name={assignee.nickname}
+              imageUrl={assignee.profileImage}
+            />
           ))}
         </SectionList>
       </SidebarSection>
@@ -78,24 +81,6 @@ const SectionList = styled.div`
 
   ${({ theme }) => theme.typography.availableMedium12};
   color: ${({ theme }) => theme.neutral.text.strong};
-`;
-
-// TODO profile 공통 컴포넌트 분리
-const ProfileImage = styled.img`
-  width: 20px;
-  height: 19px;
-  border-radius: ${({ theme }) => theme.radius.half};
-`;
-
-const Nickname = styled.span`
-  ${({ theme }) => theme.typography.displayMedium16};
-  color: ${({ theme }) => theme.neutral.text.default};
-`;
-
-const AssigneeWrapper = styled.div`
-  display: flex;
-  gap: 8px;
-  align-items: center;
 `;
 
 const MilestoneLabel = styled.span`

--- a/fe/src/features/issue/components/detail/DescriptionBox.tsx
+++ b/fe/src/features/issue/components/detail/DescriptionBox.tsx
@@ -17,8 +17,7 @@ export default function DescriptionBox({
   return (
     <Wrapper>
       <DescriptionHeader
-        profileImageUrl={author.profileImage}
-        nickname={author.nickname}
+        author={author}
         createdAt={createdAt}
         isAuthor={true} //TODO 로그인 기능 구현시 변경
       />

--- a/fe/src/features/issue/components/detail/DescriptionHeader.tsx
+++ b/fe/src/features/issue/components/detail/DescriptionHeader.tsx
@@ -1,26 +1,26 @@
 import styled from '@emotion/styled';
 import { getTimeAgoString } from '@/shared/utils/time';
+import type { Author } from '../../types/issue';
 import Profile from '@/shared/components/Profile';
 import EditIcon from '@/assets/icons/edit.svg?react';
 import SmileIcon from '@/assets/icons/smile.svg?react';
 
 interface WriterInfoProps {
-  profileImageUrl: string;
-  nickname: string;
+  author: Author;
   createdAt: string;
   isAuthor: boolean;
 }
 
 export default function WriterInfo({
-  profileImageUrl,
-  nickname,
+  author,
   createdAt,
   isAuthor = false,
 }: WriterInfoProps) {
+  const { id, nickname, profileImage } = author;
   return (
     <Container>
       <LeftSection>
-        <Profile size="md" name={nickname} imageUrl={profileImageUrl} />
+        <Profile id={id} size="md" name={nickname} imageUrl={profileImage} />
         <CreatedAt>{getTimeAgoString(createdAt)}</CreatedAt>
       </LeftSection>
 

--- a/fe/src/features/issue/components/detail/DescriptionHeader.tsx
+++ b/fe/src/features/issue/components/detail/DescriptionHeader.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { getTimeAgoString } from '@/shared/utils/time';
+import Profile from '@/shared/components/Profile';
 import EditIcon from '@/assets/icons/edit.svg?react';
 import SmileIcon from '@/assets/icons/smile.svg?react';
 
@@ -19,8 +20,7 @@ export default function WriterInfo({
   return (
     <Container>
       <LeftSection>
-        <ProfileImage src={profileImageUrl} alt="프로필 이미지" />
-        <Nickname>{nickname}</Nickname>
+        <Profile size="md" name={nickname} imageUrl={profileImageUrl} />
         <CreatedAt>{getTimeAgoString(createdAt)}</CreatedAt>
       </LeftSection>
 
@@ -57,17 +57,6 @@ const RightSection = styled.div`
   display: flex;
   align-items: center;
   gap: 16px;
-`;
-
-const ProfileImage = styled.img`
-  width: 32px;
-  height: 32px;
-  border-radius: ${({ theme }) => theme.radius.half};
-`;
-
-const Nickname = styled.span`
-  ${({ theme }) => theme.typography.displayMedium16};
-  color: ${({ theme }) => theme.neutral.text.default};
 `;
 
 const CreatedAt = styled.span`

--- a/fe/src/features/issue/components/list/issueItem/Assignees.tsx
+++ b/fe/src/features/issue/components/list/issueItem/Assignees.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import Profile from '@/shared/components/Profile';
 
 interface Props {
   assigneesProfileImages: string[];
@@ -8,12 +9,7 @@ const Assignees = ({ assigneesProfileImages }: Props) => {
   return (
     <AvatarStack>
       {assigneesProfileImages.slice(0, 5).map((url, idx) => (
-        <AssigneeAvatar
-          key={idx}
-          src={url}
-          alt={`assignee-${idx}`}
-          style={{ zIndex: 5 - idx }}
-        />
+        <Profile key={idx} size="sm" imageUrl={url} />
       ))}
       {assigneesProfileImages.length > 5 && (
         <ExtraText>+{assigneesProfileImages.length - 5}</ExtraText>
@@ -28,18 +24,18 @@ const AvatarStack = styled.div`
   display: flex;
   align-items: center;
   position: relative;
-`;
 
-const AssigneeAvatar = styled.img`
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  border: 1px solid white;
-  position: relative;
-  margin-left: -8px;
+  & > * {
+    margin-left: -8px;
+    position: relative;
+  }
 
-  &:first-of-type {
+  & > *:first-of-type {
     margin-left: 0;
+  }
+
+  & > * {
+    z-index: calc(10 - var(--order));
   }
 `;
 

--- a/fe/src/features/issue/types/issue.ts
+++ b/fe/src/features/issue/types/issue.ts
@@ -37,13 +37,15 @@ export interface Assignee {
   profileImage: string;
 }
 
+export interface Author {
+  id: number;
+  nickname: string;
+  profileImage: string;
+}
+
 export interface IssueDetailResponse {
   id: number;
-  author: {
-    id: number;
-    nickname: string;
-    profileImage: string;
-  };
+  author: Author;
   title: string;
   content: string | null;
   labels: Label[];

--- a/fe/src/shared/components/Header.tsx
+++ b/fe/src/shared/components/Header.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { Link } from 'react-router-dom';
+import Profile from './Profile';
 import Logo from '@/assets/logoMedium.svg?react';
 import DarkModeToggle from './DarkModeToggle';
 
@@ -12,7 +13,8 @@ export default function Header() {
         </Link>
         <DarkModeToggle />
       </LeftSection>
-      <Profile profileImageUrl="/images/sampleProfile.png" />
+      {/* 로그인 기능 구현시 유저 정보(이미지,id등) 전달 */}
+      <Profile size="md" />
     </Wrapper>
   );
 }
@@ -34,21 +36,4 @@ const StyledLogo = styled(Logo)`
   width: 199px;
   height: 40px;
   color: ${({ theme }) => theme.neutral.text.strong};
-`;
-
-// TODO profile 공통 컴포넌트 분리
-interface Props {
-  profileImageUrl: string;
-}
-
-const Profile = ({ profileImageUrl }: Props) => {
-  return <Avatar src={profileImageUrl} alt="user-profile" />;
-};
-
-const Avatar = styled.img`
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  border: 1px solid white;
-  object-fit: cover;
 `;

--- a/fe/src/shared/components/Profile.test.tsx
+++ b/fe/src/shared/components/Profile.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@emotion/react';
+import Profile from './Profile';
+import { lightTheme } from '@/shared/styles/theme';
+
+describe('Profile 컴포넌트', () => {
+  const renderWithTheme = (ui: React.ReactElement) =>
+    render(<ThemeProvider theme={lightTheme}>{ui}</ThemeProvider>);
+
+  it('imageUrl prop이 있으면 해당 src를 보여준다', () => {
+    const url = '/me.png';
+    renderWithTheme(<Profile imageUrl={url} />);
+    const img = screen.getByRole('img', { name: /profile image/i });
+    expect(img).toHaveAttribute('src', url);
+  });
+
+  it('imageUrl prop이 없으면 default-profile.png를 보여준다', () => {
+    renderWithTheme(<Profile imageUrl="" />);
+    const img = screen.getByRole('img', { name: /profile image/i });
+    expect(img).toHaveAttribute('src', '/images/sampleProfile.png');
+  });
+
+  it('name prop이 있으면 텍스트를 렌더링한다', () => {
+    const name = '순원';
+    renderWithTheme(<Profile imageUrl="/me.png" name={name} />);
+    expect(screen.getByText(name)).toBeInTheDocument();
+  });
+
+  it('name prop이 없으면 텍스트 엘리먼트를 렌더링하지 않는다', () => {
+    renderWithTheme(<Profile imageUrl="/me.png" />);
+    // 닉네임 span이 없으므로 queryByText로 null 확인
+    expect(screen.queryByText(/./)).toBeNull();
+  });
+});

--- a/fe/src/shared/components/Profile.tsx
+++ b/fe/src/shared/components/Profile.tsx
@@ -1,0 +1,72 @@
+/** @jsxImportSource @emotion/react */
+import styled from '@emotion/styled';
+import { css, useTheme } from '@emotion/react';
+
+interface ProfileProps {
+  id?: number;
+  size?: 'md' | 'sm';
+  name?: string;
+  imageUrl?: string;
+  alt?: string;
+}
+
+const Profile: React.FC<ProfileProps> = ({
+  id,
+  size = 'md',
+  name,
+  imageUrl,
+  alt = 'Profile image',
+}) => {
+  const theme = useTheme();
+  const avatarSrc = imageUrl || '/images/sampleProfile.png';
+
+  const variantConfig = {
+    md: {
+      avatarPx: 32,
+      typo: 'displayMedium16',
+      color: theme.neutral.text.default,
+      gap: 8,
+    },
+    sm: {
+      avatarPx: 20,
+      typo: 'displayMedium12',
+      color: theme.neutral.text.strong,
+      gap: 8,
+    },
+  } as const;
+
+  const { avatarPx, typo, color, gap } = variantConfig[size];
+  const colorValue = color;
+
+  return (
+    <Wrapper key={id} gap={gap}>
+      <Avatar src={avatarSrc} size={avatarPx} alt={alt} />
+      {name && (
+        <Name
+          css={css`
+            ${theme.typography[typo]};
+            color: ${colorValue};
+          `}
+        >
+          {name}
+        </Name>
+      )}
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div<{ gap: number }>`
+  display: flex;
+  align-items: center;
+  gap: ${({ gap }) => gap}px;
+`;
+
+const Avatar = styled.img<{ size: number }>`
+  width: ${({ size }) => size}px;
+  height: ${({ size }) => size}px;
+  border-radius: 50%;
+`;
+
+const Name = styled.span``;
+
+export default Profile;


### PR DESCRIPTION
## 📌 PR 제목

[Refactor] Profile - 공용 컴포넌트 생성 및 전역 적용

## ✅ 작업 요약

- 공용 `Profile` 컴포넌트 생성 및 GTest 기반 테스트 코드 작성  
- 기존 프로필 사용부를 모두 `Profile` 컴포넌트로 교체  

### 서브 작업
- `IssueMainSection`, `DescriptionBox` 등에서 `author` 관련 prop을 primitive 분리 방식에서 **`author` 객체** 전달 방식으로 전환

## ✅ 테스트 확인

- [x] 공용 `Profile` 컴포넌트 생성 및 테스트 코드 통과 확인  
- [x] 모든 화면에 `Profile` 컴포넌트 적용 완료  
- [x] 기본 아바타 이미지(`/public/default-avatar.png`) 로드 확인  

## 🧠 회고/고민

- **객체 통째 전달 vs primitive props 전달**  
  - 객체 전달로 인터페이스를 간소화하고, 호출부·자식부 간 시그니처 변경을 최소화하도록 결정  
- **`React.memo` 최적화 고려 사항**  
  - 현재 렌더링 비용이 크지 않아 메모 최적화를 적용하지 않기로 하고, 추후 필요 시 검토하기로 함  
- **`useMemo` 적용 여부 결정**  
  - 복잡하거나 무거운 계산 로직이 없으므로 `useMemo`를 사용하지 않기로 결정  
- **컴포넌트 내부 `variantConfig` 정의 vs 테마 폴더 통합**  
  - 중복 코드 증가 및 테마 일관성 관리 차원에서 테마 통합을 선택  
- **`imageUrl` optional 처리 및 기본 이미지 제공**  
  - optional 처리로 호출부 부담을 줄이고, 기본 이미지로 UX를 보완  
- **`id` prop 필수화**  
  - 클릭 이벤트 및 접근성 로직에서 고유 식별자 확보가 필요하여 필수로 지정  

closes #102