### PR TITLE
[Refactor] useQuery의 data 기본값 구조 분해 처리

### DIFF
--- a/fe/src/features/issue/components/list/IssueListContainer.tsx
+++ b/fe/src/features/issue/components/list/IssueListContainer.tsx
@@ -16,19 +16,16 @@ export default function IssueListContainer({
   onChangeTab,
 }: IssueListContainerProps) {
   const query = buildIssueQuery(selected);
-  const { data: issues, isFetching, isError, error } = useIssues(query);
+  const { issueList, openCount, closeCount, isFetching, isError, error } =
+    useIssues(query);
 
-  const prevIssues = usePreviousWhen(issues?.issues ?? [], !isFetching);
-  const prevOpenCount = usePreviousWhen(issues?.openCount ?? 0, !isFetching);
-  const prevCloseCount = usePreviousWhen(issues?.closeCount ?? 0, !isFetching);
+  const prevIssues = usePreviousWhen(issueList, !isFetching);
+  const prevOpenCount = usePreviousWhen(openCount, !isFetching);
+  const prevCloseCount = usePreviousWhen(closeCount, !isFetching);
 
-  const displayIssues = isFetching ? prevIssues : (issues?.issues ?? []);
-  const displayOpenCount = isFetching
-    ? prevOpenCount
-    : (issues?.openCount ?? 0);
-  const displayCloseCount = isFetching
-    ? prevCloseCount
-    : (issues?.closeCount ?? 0);
+  const displayIssues = isFetching ? prevIssues : issueList;
+  const displayOpenCount = isFetching ? prevOpenCount : openCount;
+  const displayCloseCount = isFetching ? prevCloseCount : closeCount;
 
   if (isError) {
     console.error('[이슈 목록 로딩 에러]', error);

--- a/fe/src/features/issue/hooks/useIssueComments.ts
+++ b/fe/src/features/issue/hooks/useIssueComments.ts
@@ -3,10 +3,15 @@ import fetchIssueComments from '../api/getIssueComments';
 import { type Comment } from '../types/issue';
 
 export default function useIssueComments(issueId: number) {
-  return useQuery<Comment[]>({
+  const { data, ...rest } = useQuery<Comment[]>({
     queryKey: ['issueComments', issueId],
     queryFn: () => fetchIssueComments(issueId),
     enabled: !!issueId,
     retry: false,
   });
+
+  return {
+    commentList: data ?? [],
+    ...rest,
+  };
 }

--- a/fe/src/features/issue/hooks/useIssueDetail.ts
+++ b/fe/src/features/issue/hooks/useIssueDetail.ts
@@ -2,10 +2,15 @@ import { useQuery } from '@tanstack/react-query';
 import getIssueDetail from '../api/getIssueDetail';
 
 export default function useIssueDetail(issueId: number) {
-  return useQuery({
+  const { data, ...rest } = useQuery({
     queryKey: ['issueDetail', issueId],
     queryFn: () => getIssueDetail(issueId),
     enabled: !!issueId,
     retry: false,
   });
+
+  return {
+    issueDetail: data ?? null,
+    ...rest,
+  };
 }

--- a/fe/src/features/issue/hooks/useIssues.ts
+++ b/fe/src/features/issue/hooks/useIssues.ts
@@ -2,8 +2,15 @@ import { useQuery } from '@tanstack/react-query';
 import { getIssues } from '../api/getIssues';
 
 export default function useIssues(filterQuery: string) {
-  return useQuery({
+  const { data, ...rest } = useQuery({
     queryKey: ['issues', filterQuery],
     queryFn: () => getIssues(filterQuery),
   });
+
+  return {
+    issueList: data?.issues ?? [],
+    openCount: data?.openCount ?? 0,
+    closeCount: data?.closeCount ?? 0,
+    ...rest,
+  };
 }

--- a/fe/src/pages/IssueDetailPage.tsx
+++ b/fe/src/pages/IssueDetailPage.tsx
@@ -16,13 +16,13 @@ export default function IssueDetailPage() {
   const navigate = useNavigate();
 
   const {
-    data: issueDetailData,
+    issueDetail,
     isLoading: isIssueDetailLoading,
     isError: isIssueDetailError,
   } = useIssueDetail(issueId);
 
   const {
-    data: commentData,
+    commentList,
     isLoading: isCommentLoading,
     isError: isCommentError,
   } = useIssueComments(issueId);
@@ -38,28 +38,28 @@ export default function IssueDetailPage() {
   if (isIssueDetailLoading || isCommentLoading) return <div>로딩 중...</div>;
 
   if (isIssueDetailError || isCommentError) return <div>에러 발생</div>;
-  if (!issueDetailData || !commentData) return;
+  if (!issueDetail || !commentList) return;
 
   return (
     <VerticalStack>
       <IssueHeader
-        {...issueDetailData}
-        issueNumber={issueDetailData.id}
-        commentCount={commentData?.length ?? 0}
+        {...issueDetail}
+        issueNumber={issueDetail.id}
+        commentCount={commentList.length}
       />
       <Divider />
       <MainArea>
         <IssueMainSection
-          comments={commentData ?? []}
-          content={issueDetailData.content}
-          createdAt={issueDetailData.createdAt}
-          author={issueDetailData.author}
+          comments={commentList}
+          content={issueDetail.content}
+          createdAt={issueDetail.createdAt}
+          author={issueDetail.author}
         />
         <SideSection>
           <IssueSidebar
-            assignees={issueDetailData.assignees}
-            labels={issueDetailData.labels}
-            milestone={issueDetailData.milestone}
+            assignees={issueDetail.assignees}
+            labels={issueDetail.labels}
+            milestone={issueDetail.milestone}
           />
           <TabItem icon={<TrashIcon />} label="이슈 삭제" />
         </SideSection>


### PR DESCRIPTION
## 📌 PR 제목

[Refactor] useQuery의 data 기본값 구조 분해 처리

## ✅ 작업 요약

- React Query의 `data`가 초기 `undefined`일 때 안전하게 처리하기 위해 `??` 연산자로 기본값 설정  
- `useIssues`, `useIssueDetail`, `useIssueComments` 훅 내에서 `data`를 `issueList`, `openCount`, `commentList` 등 의미 있는 변수명으로 구조 분해  
- `...rest`로 React Query 상태값(`isLoading`, `isError`)을 분리 반환해 컴포넌트에서 optional chaining 없이 값 접근 가능  

## ✅ 테스트 확인

- [ ] 컴포넌트에서 optional chaining 없이 `issueList`, `openCount`, `commentList` 등에 접근 가능한지 검증  

## 🧠 회고/고민

- **`data` 기본값 처리 고민**  
  React Query 훅의 `data`가 초기에는 `undefined`여서 컴포넌트에서 매번 `data?.field`로 optional chaining을 사용해야 했습니다. 이로 인해 코드 중복과 가독성 저하가 발생하여, 훅 내부에서 `??` 연산자로 기본값(`[]`, `0` 등)을 설정해 컴포넌트는 안전하게 데이터에 접근하도록 개선했습니다.

- **변수명 설계 및 상태값 분리 고민**  
  `data` 객체 안 필드만 바로 사용할 경우, `isLoading`, `isError` 상태와 혼용되어 데이터 흐름이 불명확해집니다. 그래서 `issueList`, `openCount`, `commentList` 등 의미 있는 변수명으로 구조 분해하고, 나머지 상태값은 `...rest`로 분리 반환해 역할을 명확히 구분했습니다.

- **호환성 및 안정성 확보 고민**  
  기존 컴포넌트들이 optional chaining 방식을 전제하고 있어 기본값 설정으로 인한 부작용 우려가 있었습니다. TypeScript 타입 정의를 보강하고, 리팩토링 전/후 테스트를 통해 기존 동작이 동일함을 검증하여 안정성을 확보했습니다.

closes #74 