### PR TITLE
[Feature] 공용 버튼 컴포넌트 생성 및 전역 적용

### DIFF
--- a/fe/src/features/issue/components/CreateIssueButton.tsx
+++ b/fe/src/features/issue/components/CreateIssueButton.tsx
@@ -1,37 +1,17 @@
-import styled from '@emotion/styled';
 import { useNavigate } from 'react-router-dom';
+import Button from '@/shared/components/Button';
 import PlusIcon from '@/assets/icons/plus.svg?react';
 
 export default function CreateIssueButton() {
   const navigate = useNavigate();
 
   return (
-    <StyledButton onClick={() => navigate('/issues/new')}>
-      <PlusIcon />
-      <StyledLabel>이슈 작성</StyledLabel>
-    </StyledButton>
+    <Button
+      size="small"
+      icon={<PlusIcon />}
+      onClick={() => navigate('/issues/new')}
+    >
+      이슈 작성
+    </Button>
   );
 }
-
-const StyledButton = styled.button`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 128px;
-  padding: 12px 0;
-  background-color: ${({ theme }) => theme.palette.blue};
-  border-radius: ${({ theme }) => theme.radius.medium};
-  color: #ffffff;
-
-  cursor: pointer;
-  transition: all 0.2s ease;
-
-  &:hover {
-    opacity: 0.8;
-  }
-`;
-
-const StyledLabel = styled.span`
-  padding: 0 4px;
-  ${({ theme }) => theme.typography.availableMedium12};
-`;

--- a/fe/src/features/issue/components/detail/DescriptionHeader.tsx
+++ b/fe/src/features/issue/components/detail/DescriptionHeader.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { getTimeAgoString } from '@/shared/utils/time';
 import type { Author } from '../../types/issue';
+import Button from '@/shared/components/Button';
 import Profile from '@/shared/components/Profile';
 import EditIcon from '@/assets/icons/edit.svg?react';
 import SmileIcon from '@/assets/icons/smile.svg?react';
@@ -26,14 +27,27 @@ export default function DescriptionHeader({
 
       <RightSection>
         {isAuthor && <AuthorTag>작성자</AuthorTag>}
-        <IconButton variant="edit">
-          <EditIcon />
+        <Button
+          variant="ghost"
+          size="small"
+          icon={<EditIcon />}
+          onClick={() => {
+            /* 편집 로직 */
+          }}
+        >
           편집
-        </IconButton>
-        <IconButton variant="reaction">
-          <SmileIcon />
+        </Button>
+
+        <Button
+          variant="ghost"
+          size="small"
+          icon={<SmileIcon />}
+          onClick={() => {
+            /* 반응 로직 */
+          }}
+        >
           반응
-        </IconButton>
+        </Button>
       </RightSection>
     </Container>
   );
@@ -71,17 +85,4 @@ const AuthorTag = styled.span`
   border-radius: ${({ theme }) => theme.radius.medium};
   ${({ theme }) => theme.typography.displayMedium12};
   color: ${({ theme }) => theme.neutral.text.weak};
-`;
-
-//TODO 공용 버튼 컴포넌트 구현시 통합
-const IconButton = styled.button<{ variant: 'edit' | 'reaction' }>`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
-  height: 100%;
-  color: ${({ theme }) => theme.neutral.text.default};
-  ${({ theme }) => theme.typography.availableMedium12};
-
-  cursor: pointer;
 `;

--- a/fe/src/features/issue/components/detail/IssueHeader.tsx
+++ b/fe/src/features/issue/components/detail/IssueHeader.tsx
@@ -3,6 +3,7 @@ import { formatCreatedMessage } from '@/features/issue/utils';
 import ClosedIcon from '@/assets/icons/archive.svg?react';
 import EditIcon from '@/assets/icons/edit.svg?react';
 import AlertCircleIcon from '@/assets/icons/alertCircle.svg?react';
+import Button from '@/shared/components/Button';
 
 interface IssueHeaderProps {
   isClosed: boolean;
@@ -44,14 +45,26 @@ export default function IssueHeader({
         </IssueMetaWrapper>
       </LeftSection>
       <RightSection>
-        <StyledButton>
-          <EditIcon />
-          <StyledLabel>제목 편집</StyledLabel>
-        </StyledButton>
-        <StyledButton>
-          <ClosedIcon />
-          <StyledLabel>{isClosed ? '이슈 열기' : '이슈 닫기'}</StyledLabel>
-        </StyledButton>
+        <Button
+          variant="outline"
+          size="small"
+          icon={<EditIcon />}
+          onClick={() => {
+            /* 편집 로직 */
+          }}
+        >
+          제목 편집
+        </Button>
+        <Button
+          variant="outline"
+          size="small"
+          icon={<ClosedIcon />}
+          onClick={() => {
+            /* 이슈 열기/닫기 토글 로직 */
+          }}
+        >
+          {isClosed ? '이슈 열기' : '이슈 닫기'}
+        </Button>
       </RightSection>
     </HeaderWrapper>
   );
@@ -104,27 +117,6 @@ const CommentCount = styled.span`
   margin-left: 24px;
   color: ${({ theme }) => theme.neutral.text.weak};
   ${({ theme }) => theme.typography.displayMedium16};
-`;
-
-//TODO 공용 버튼 생성시 StyledButton, IsClosedButton 통합
-const StyledButton = styled.button`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 128px;
-  height: 40px;
-  padding: 12px 0;
-  border: 1px solid ${({ theme }) => theme.palette.blue};
-  border-radius: ${({ theme }) => theme.radius.medium};
-  color: ${({ theme }) => theme.palette.blue};
-  ${({ theme }) => theme.typography.availableMedium12};
-
-  cursor: pointer;
-`;
-
-const StyledLabel = styled.span`
-  padding: 0 4px;
-  ${({ theme }) => theme.typography.availableMedium12};
 `;
 
 const IsClosedButton = styled.button`

--- a/fe/src/features/issue/components/list/IssueTabButton.tsx
+++ b/fe/src/features/issue/components/list/IssueTabButton.tsx
@@ -1,0 +1,23 @@
+import Button from '@/shared/components/Button';
+
+interface TabItemProps {
+  icon: React.ReactNode;
+  label: string;
+  count: number;
+  selected: boolean;
+  onClick: () => void;
+}
+
+export default function TabItem({
+  icon,
+  label,
+  count,
+  selected,
+  onClick,
+}: TabItemProps) {
+  return (
+    <Button variant="ghost" icon={icon} selected={selected} onClick={onClick}>
+      {`${label}(${count})`}
+    </Button>
+  );
+}

--- a/fe/src/features/issue/components/list/IssueTabFilter.tsx
+++ b/fe/src/features/issue/components/list/IssueTabFilter.tsx
@@ -1,28 +1,13 @@
 import styled from '@emotion/styled';
 import ClosedIcon from '@/assets/icons/archive.svg?react';
 import OpenIcon from '@/assets/icons/alertCircle.svg?react';
-
-interface TabItemProps {
-  icon: React.ReactNode;
-  label: string;
-  active: boolean;
-  onClick: () => void;
-}
+import IssueTabButton from './IssueTabButton';
 
 interface IssueTabFilterProps {
   openCount: number;
   closeCount: number;
   selected: 'open' | 'closed';
   onChangeTab: (status: 'open' | 'closed') => void;
-}
-
-function TabItem({ icon, label, active, onClick }: TabItemProps) {
-  return (
-    <TabButton active={active} onClick={onClick}>
-      <IconWrapper>{icon}</IconWrapper>
-      <Label>{label}</Label>
-    </TabButton>
-  );
 }
 
 export default function IssueTabFilter({
@@ -33,16 +18,18 @@ export default function IssueTabFilter({
 }: IssueTabFilterProps) {
   return (
     <TabWrapper>
-      <TabItem
+      <IssueTabButton
         icon={<OpenIcon />}
-        label={`열린 이슈 (${openCount})`}
-        active={selected === 'open'}
+        label="열린 이슈"
+        count={openCount}
+        selected={selected === 'open'}
         onClick={() => onChangeTab('open')}
       />
-      <TabItem
+      <IssueTabButton
         icon={<ClosedIcon />}
-        label={`닫힌 이슈 (${closeCount})`}
-        active={selected === 'closed'}
+        label="닫힌 이슈"
+        count={closeCount}
+        selected={selected === 'closed'}
         onClick={() => onChangeTab('closed')}
       />
     </TabWrapper>
@@ -52,35 +39,4 @@ export default function IssueTabFilter({
 const TabWrapper = styled.div`
   display: flex;
   gap: 24px;
-`;
-
-const TabButton = styled.button<{ active?: boolean }>`
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 4px 0;
-  color: ${({ active, theme }) =>
-    active ? theme.neutral.text.strong : theme.neutral.text.default};
-  ${({ theme }) => theme.typography.selectedBold16};
-
-  cursor: pointer;
-
-  &:hover {
-    opacity: 0.8;
-  }
-`;
-
-const IconWrapper = styled.span`
-  display: flex;
-  align-items: center;
-  color: inherit;
-
-  svg {
-    width: 16px;
-    height: 16px;
-  }
-`;
-
-const Label = styled.span`
-  color: inherit;
 `;

--- a/fe/src/shared/components/Button.test.tsx
+++ b/fe/src/shared/components/Button.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@emotion/react';
+import userEvent from '@testing-library/user-event';
+import { lightTheme } from '@/shared/styles/theme';
+import Button from './Button';
+
+const OUTLINE_BORDER_COLOR = lightTheme.brand.border.default;
+
+describe('Button 컴포넌트', () => {
+  const renderWithTheme = (ui: React.ReactElement) =>
+    render(<ThemeProvider theme={lightTheme}>{ui}</ThemeProvider>);
+
+  it('children 텍스트가 표시되어야 한다', () => {
+    renderWithTheme(<Button>확인</Button>);
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveTextContent('확인');
+  });
+
+  it('variant가 outline일 경우 border가 있어야 한다', () => {
+    renderWithTheme(<Button variant="outline">테스트</Button>);
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveStyle(
+      `box-shadow: inset 0 0 0 1px ${OUTLINE_BORDER_COLOR}`,
+    );
+  });
+
+  it('fullWidth이면 width가 100%여야 한다', () => {
+    renderWithTheme(<Button fullWidth>전체 너비</Button>);
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveStyle('width: 100%');
+  });
+
+  it('disabled면 클릭되지 않아야 한다', async () => {
+    const onClick = vi.fn();
+    renderWithTheme(
+      <Button disabled onClick={onClick}>
+        비활성화
+      </Button>,
+    );
+    const btn = screen.getByRole('button');
+    await userEvent.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('selected면 bold체가 되어야 한다', () => {
+    renderWithTheme(<Button selected={true}>선택됨</Button>);
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveStyle('font-weight: 700');
+  });
+});

--- a/fe/src/shared/components/Button.tsx
+++ b/fe/src/shared/components/Button.tsx
@@ -1,0 +1,184 @@
+/** @jsxImportSource @emotion/react */
+import { type ButtonHTMLAttributes, type ReactNode } from 'react';
+import styled from '@emotion/styled';
+import { css } from '@emotion/react';
+import type { ThemeType } from '../styles/theme';
+
+// ✅ 타입 정의
+type ButtonVariant = 'contained' | 'outline' | 'ghost';
+type ButtonSize = 'large' | 'medium' | 'small';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  fullWidth?: boolean;
+  icon?: ReactNode;
+  selected?: boolean;
+  children: ReactNode;
+}
+
+interface StyledButtonProps {
+  variant: ButtonVariant;
+  size: ButtonSize;
+  fullWidth: boolean;
+  selected: boolean;
+}
+
+interface TextWrapperProps {
+  variant: ButtonVariant;
+  size: ButtonSize;
+}
+
+// ✅ Button 컴포넌트 본체
+const Button: React.FC<ButtonProps> = ({
+  variant = 'contained',
+  size = 'medium',
+  fullWidth = false,
+  icon,
+  selected = false,
+  children,
+  ...rest
+}) => {
+  return (
+    <StyledButton
+      type="button"
+      variant={variant}
+      size={size}
+      fullWidth={fullWidth}
+      selected={selected}
+      {...rest}
+    >
+      {icon}
+      <TextWrapper variant={variant} size={size}>
+        {children}
+      </TextWrapper>
+    </StyledButton>
+  );
+};
+
+export default Button;
+
+// ✅ 스타일 컴포넌트
+const StyledButton = styled.button<StyledButtonProps>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: ${({ variant, theme }) =>
+    variant === 'ghost' ? theme.spacing.button.gap.small : '0px'};
+  cursor: pointer;
+  transition:
+    background-color 0.15s,
+    filter 0.15s;
+
+  ${({ theme, variant }) => getVariantStyle(theme, variant)};
+  ${({ theme, variant }) => css`
+    padding-top: ${getPaddingY(theme, variant)};
+    padding-bottom: ${getPaddingY(theme, variant)};
+  `}
+  ${({ theme, size, selected }) => getTypography(theme, size, selected)};
+  ${({ theme, size, variant, fullWidth }) =>
+    getWidthStyle(theme, size, variant, fullWidth)}
+
+  border-radius: ${({ theme }) => theme.radius.medium};
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+`;
+
+const TextWrapper = styled.span<TextWrapperProps>`
+  padding-inline: ${({ variant, size, theme }) =>
+    variant === 'ghost' ? '0px' : getPaddingInline(theme, size)};
+`;
+
+// ✅ 유틸 함수 및 상수
+const sizeToTypoKey: Record<ButtonSize, keyof ThemeType['typography']> = {
+  large: 'availableMedium20',
+  medium: 'availableMedium16',
+  small: 'availableMedium12',
+};
+
+const sizeToSelectedTypoKey: Record<ButtonSize, keyof ThemeType['typography']> =
+  {
+    large: 'selectedBold20',
+    medium: 'selectedBold16',
+    small: 'selectedBold12',
+  };
+
+const getTypography = (
+  theme: ThemeType,
+  size: ButtonSize,
+  selected: boolean,
+) => {
+  const key = selected ? sizeToSelectedTypoKey[size] : sizeToTypoKey[size];
+  return theme.typography[key];
+};
+
+const getWidthStyle = (
+  theme: ThemeType,
+  size: ButtonSize,
+  variant: ButtonVariant,
+  fullWidth: boolean,
+) => {
+  if (fullWidth)
+    return css`
+      width: 100%;
+    `;
+  if (variant !== 'ghost') {
+    return css`
+      width: ${theme.spacing.button.width[size]};
+    `;
+  }
+  return css``;
+};
+
+const getPaddingInline = (theme: ThemeType, size: ButtonSize): string => {
+  return size === 'small'
+    ? theme.spacing.base.xsmall
+    : theme.spacing.base.small;
+};
+
+const getPaddingY = (theme: ThemeType, variant: ButtonVariant) =>
+  variant === 'ghost'
+    ? theme.spacing.button.paddingY.ghost
+    : theme.spacing.button.paddingY.default;
+
+const getVariantStyle = (theme: ThemeType, variant: ButtonVariant) =>
+  variantStyles[variant](theme);
+
+const variantStyles = {
+  contained: (theme: ThemeType) => css`
+    background-color: ${theme.brand.surface.default};
+    color: ${theme.brand.text.default};
+    border: none;
+    &:hover {
+      filter: brightness(0.9);
+    }
+    &:active {
+      filter: brightness(0.8);
+    }
+  `,
+  outline: (theme: ThemeType) => css`
+    background-color: transparent;
+    color: ${theme.brand.border.default};
+    box-shadow: inset 0 0 0 1px ${theme.brand.border.default};
+    &:hover {
+      background-color: ${theme.neutral.surface.default};
+    }
+    &:active {
+      background-color: ${theme.neutral.surface.bold};
+    }
+  `,
+  ghost: (theme: ThemeType) => css`
+    background-color: transparent;
+    color: ${theme.neutral.text.default};
+    border: none;
+    &:hover {
+      background-color: ${theme.neutral.surface.default};
+    }
+    &:active {
+      background-color: ${theme.neutral.surface.bold};
+    }
+  `,
+} as const;

--- a/fe/src/shared/components/TabItem.tsx
+++ b/fe/src/shared/components/TabItem.tsx
@@ -1,5 +1,5 @@
-import styled from '@emotion/styled';
 import { type ReactNode } from 'react';
+import Button from './Button';
 
 interface TabItemProps {
   icon: ReactNode;
@@ -16,36 +16,14 @@ export default function TabItem({
   isActive = false,
 }: TabItemProps) {
   return (
-    <TabItemWrapper onClick={onClick} isActive={isActive}>
-      {icon}
-      <TabLabel isActive={isActive}>{`${label}(${count})`}</TabLabel>
-    </TabItemWrapper>
+    <Button
+      variant="ghost"
+      fullWidth={true}
+      icon={icon}
+      selected={isActive}
+      onClick={onClick}
+    >
+      {`${label}(${count})`}
+    </Button>
   );
 }
-
-const TabItemWrapper = styled.button<{ isActive: boolean }>`
-  width: 160px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  padding: 8px 0;
-
-  cursor: pointer;
-
-  background-color: ${({ isActive, theme }) =>
-    isActive ? theme.neutral.surface.bold : theme.neutral.surface.default};
-  color: ${({ isActive, theme }) =>
-    isActive ? theme.neutral.text.strong : theme.neutral.text.default};
-
-  &:hover {
-    opacity: ${({ theme }) => theme.opacity.hover};
-  }
-`;
-
-const TabLabel = styled.span<{ isActive: boolean }>`
-  ${({ isActive, theme }) =>
-    isActive
-      ? theme.typography.selectedBold16
-      : theme.typography.availableMedium16};
-`;

--- a/fe/src/shared/styles/theme.common.ts
+++ b/fe/src/shared/styles/theme.common.ts
@@ -23,6 +23,30 @@ const commonTheme = {
     navy: accent.navy,
     red: accent.red,
   },
+  spacing: {
+    base: {
+      xsmall: '4px',
+      small: '8px',
+      medium: '16px',
+      large: '24px',
+      xlarge: '32px',
+    },
+    button: {
+      paddingY: {
+        ghost: '8px',
+        default: '12px',
+      },
+      width: {
+        small: '128px',
+        medium: '184px',
+        large: '240px',
+      },
+      gap: {
+        small: '4px',
+        default: '8px',
+      },
+    },
+  },
 };
 
 export default commonTheme;


### PR DESCRIPTION
## 📌 PR 제목

[Feature] 공용 버튼 컴포넌트 생성 및 전역 적용

## ✅ 작업 요약

- theme.ts에 간격 값 추가(spacing)
- 공용 `Button` 컴포넌트를 생성하여 전역에서 사용할 수 있도록 설계함
- `variant`, `size`, `icon`, `selected`, `fullWidth` 등 다양한 props를 지원
- 버튼 내 `icon`과 `text` 간 간격(gap, paddingInline)을 variant 기준으로 분리 적용
- `TextWrapper`를 분리하여 텍스트에만 `padding-inline` 적용
- `selected` 상태에서 타이포그래피 강조 적용 (`theme.typography`)
- `getTypography`, `getWidthStyle`, `getPaddingInline` 등 유틸 함수로 스타일 조건 분기 로직을 함수화하여 가독성과 재사용성 개선
- 기존 버튼 사용 화면에 적용 (ex. 이슈 상태 토글, 탭 필터 등)



## ✅ 테스트 확인

- [x] 모든 variant/size 조합에서 버튼 스타일이 올바르게 적용됨
- [x] 아이콘 유무에 따른 gap/padding이 정상적으로 작동함
- [x] `selected` 상태에 따라 타이포그래피 스타일이 변경됨
- [x] 실제 사용하는 화면에서 스타일/동작 확인 완료



## 🧠 회고/고민

### 1. **icon과 텍스트 간 간격 처리: gap vs paddingInline**

- **고민 지점**  
  variant마다 아이콘과 텍스트 사이 간격 처리 방식이 달랐음  
  - `ghost`: gap 사용 (icon과 text 사이 여백만 필요)  
  - `outline`, `contained`: gap 없음, 대신 텍스트에 padding 필요

- **시도했던 방식들**
  - `gap`과 `padding`을 `StyledButton`에서 variant 조건으로 모두 처리 → 구조 복잡, 역할 혼재
  - JSX에서 icon/text 각각 분리 후 조건부 스타일 처리 → variant별 로직 명확해짐

- **최종 선택**  
  icon은 그대로 렌더링, text만 `TextWrapper`로 감싸 paddingInline 적용  
  `StyledButton`은 gap만 담당 (역할 분리)

- **장점**
  - 역할이 명확해져서 유지보수 쉬움
  - 조건별 스타일 분기를 뷰 단에서 명확히 드러냄

- **단점**
  - JSX가 약간 복잡해짐 (추가적인 span, 조건 분기 필요)

---

### 2. **padding 처리 방식: 스타일 컴포넌트 vs JSX 조건 처리**

- **고민 지점**  
  padding-inline은 text에만 들어가야 하고, paddingY는 전체 버튼에 들어가야 함  
  StyledButton에 `padding: ${Y} ${X}` 형태로 넣으면 icon에도 padding이 들어가게 되는 문제 발생

- **시도했던 방식들**
  - StyledButton에서 `paddingY`, `paddingX` 한꺼번에 적용 → ❌ icon에까지 padding 들어감
  - JSX에서 `text`만 별도로 감싸 paddingInline 적용 → ✅ 해결

- **최종 선택**  
  `paddingY`는 `StyledButton`에서, `paddingInline`은 `TextWrapper`에서 처리

- **장점**
  - 위치별 padding 명확하게 분리
  - layout 버그 없음

- **단점**
  - JSX에 wrapper가 추가되면서 DOM 구조가 한 단계 늘어남

---

### 3. **스타일 분기 로직 위치: StyledButton 내부 vs 함수 분리**

- **고민 지점**  
  조건 분기 (`variant`, `size`, `selected`, `fullWidth`)가 많아지면서  
  StyledButton 안에 삼항 연산자가 복잡하게 얽힘 → 가독성 저하

- **시도했던 방식들**
  - StyledButton 내부에 삼항 연산자 직접 작성
  - `getTypography`, `getWidthStyle`, `getPaddingInline` 등 함수로 추출

- **최종 선택**  
  모든 조건 분기 로직은 `getXxxStyle()` 함수로 외부 분리

- **장점**
  - 가독성 향상, 로직 단위로 분리되어 테스트 가능
  - 같은 로직 다른 컴포넌트에서도 재사용 가능

- **단점**
  - 스타일 정의가 한눈에 보이지 않음 (추적은 더 쉬워졌지만 처음 읽는 입장에선 분산됨)

---

### 4. **컴포넌트 내부 정렬 순서: 스타일을 아래로 내릴 것인가**

- **고민 지점**  
  기존 프로젝트 전체 흐름이 `본체 위, 스타일 아래`였음  
  이와 다르게 `StyledComponent`를 위에 두면 일관성이 깨짐

- **최종 선택**  
  Button 본체는 위에, `StyledButton`, `TextWrapper`, 유틸 함수는 아래로 정렬

- **장점**
  - 프로젝트 전체 컨벤션 유지
  - JSX만 보고도 전체 흐름 이해 가능

- **단점**
  - StyledComponent를 보고 싶으면 파일 하단까지 내려가야 함


## 🔗 참고 자료

- [Emotion 공식 문서 - styled components](https://emotion.sh/docs/styled)

closes #1 