### PR TITLE
[Feature] 이슈 생성 페이지 기본 구조 및 입력 필드 구현, 개발환경 설정 추가

### DIFF
--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -23,6 +23,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
+        "@types/node": "^22.15.21",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.4.1",
@@ -2450,13 +2451,11 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.17.tgz",
-      "integrity": "sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==",
+      "version": "22.15.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.21.tgz",
+      "integrity": "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -8245,9 +8244,7 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",

--- a/fe/package.json
+++ b/fe/package.json
@@ -36,6 +36,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "@types/node": "^22.15.21",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",

--- a/fe/src/assets/icons/grip.svg
+++ b/fe/src/assets/icons/grip.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 18L18 10" stroke="#6E7191"/>
+<path d="M2 18L18 2" stroke="#6E7191"/>
+</svg>

--- a/fe/src/features/newIssue/components/CommentInputSection.tsx
+++ b/fe/src/features/newIssue/components/CommentInputSection.tsx
@@ -1,0 +1,115 @@
+/** @jsxImportSource @emotion/react */
+import { useEffect, useRef, useState } from 'react';
+import styled from '@emotion/styled';
+import CommentMetaBar from './CommentMetaBar';
+
+interface CommentInputSectionProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export default function CommentInputSection({
+  value,
+  onChange,
+}: CommentInputSectionProps) {
+  const [isFocused, setIsFocused] = useState(false);
+  const [showCharCount, setShowCharCount] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileUpload = () => {
+    // TODO file upload 로직
+  };
+
+  const handleCharCountVisibility = (value: string) => {
+    if (!value) {
+      setShowCharCount(false);
+      return;
+    }
+
+    setShowCharCount(true);
+
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => {
+      setShowCharCount(false);
+    }, 2000);
+  };
+
+  useEffect(() => {
+    handleCharCountVisibility(value);
+  }, [value]);
+
+  return (
+    <EditorContainer isFocused={isFocused}>
+      <LabelAbove isFloating={isFocused || !!value}>
+        코멘트를 입력하세요
+      </LabelAbove>
+      <ContentTextarea
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+      />
+
+      <CommentMetaBar
+        showCharCount={showCharCount}
+        charCount={value.length}
+        onUploadClick={() => fileInputRef.current?.click()}
+        onFileChange={handleFileUpload}
+        fileInputRef={fileInputRef}
+      />
+    </EditorContainer>
+  );
+}
+
+const EditorContainer = styled.section<{ isFocused: boolean }>`
+  position: relative;
+  height: auto;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border-radius: ${({ theme }) => theme.radius.medium};
+  overflow: hidden;
+
+  background-color: ${({ isFocused, theme }) =>
+    isFocused ? theme.neutral.surface.default : theme.neutral.surface.bold};
+
+  box-shadow: ${({ isFocused, theme }) =>
+    isFocused ? `0 0 0 1px ${theme.neutral.border.active}` : 'none'};
+`;
+
+//TODO 공통 컴포넌트 추출
+const LabelAbove = styled.label<{ isFloating: boolean }>`
+  position: absolute;
+  left: 16px;
+  top: ${({ isFloating }) => (isFloating ? '8px' : '19px')};
+  ${({ theme, isFloating }) =>
+    isFloating
+      ? theme.typography.displayMedium12
+      : theme.typography.displayMedium16};
+  transform: none;
+  color: ${({ theme }) => theme.neutral.text.weak};
+  pointer-events: none;
+  transition: all 0.2s ease;
+`;
+
+const ContentTextarea = styled.textarea`
+  width: 100%;
+  height: 300px;
+  padding: 28px 16px 16px;
+  border: none;
+  background-color: transparent;
+  color: ${({ theme }) => theme.neutral.text.strong};
+  resize: none;
+
+  ${({ theme }) => theme.typography.displayMedium16};
+
+  &::placeholder {
+    color: ${({ theme }) => theme.neutral.text.weak};
+  }
+
+  &:focus {
+    outline: none;
+  }
+`;

--- a/fe/src/features/newIssue/components/CommentMetaBar.tsx
+++ b/fe/src/features/newIssue/components/CommentMetaBar.tsx
@@ -1,0 +1,84 @@
+import styled from '@emotion/styled';
+import Button from '@/shared/components/Button';
+import PaperClipIcon from '@/assets/icons/paperclip.svg?react';
+import GripIcon from '@/assets/icons/grip.svg?react';
+
+interface CommentMetaBarProps {
+  showCharCount: boolean;
+  charCount: number;
+  onUploadClick: () => void;
+  onFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
+}
+
+export default function CommentMetaBar({
+  showCharCount,
+  charCount,
+  onUploadClick,
+  onFileChange,
+  fileInputRef,
+}: CommentMetaBarProps) {
+  return (
+    <BottomMetaWrapper>
+      <LeftMeta>
+        <CharCount visible={showCharCount}>
+          띄어쓰기 포함 {charCount}자
+        </CharCount>
+        <GripIcon />
+      </LeftMeta>
+      <RightMeta>
+        <Button
+          variant="ghost"
+          size="small"
+          icon={<PaperClipIcon />}
+          onClick={onUploadClick}
+        >
+          파일 첨부하기
+        </Button>
+
+        <input
+          ref={fileInputRef}
+          id="fileInput"
+          type="file"
+          accept="image/*"
+          style={{ display: 'none' }}
+          onChange={onFileChange}
+        />
+      </RightMeta>
+    </BottomMetaWrapper>
+  );
+}
+
+const BottomMetaWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 0 16px;
+`;
+
+const LeftMeta = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 16px 0;
+
+  color: ${({ theme }) => theme.neutral.text.weak};
+`;
+
+const CharCount = styled.span<{ visible: boolean }>`
+  display: inline-block;
+  color: ${({ theme }) => theme.neutral.text.weak};
+  opacity: ${({ visible }) => (visible ? 1 : 0)};
+  transition:
+    opacity 0.3s ease,
+    transform 0.3s ease;
+
+  ${({ theme }) => theme.typography.displayMedium12};
+`;
+
+const RightMeta = styled.div`
+  padding: 10px 0;
+  border-top: ${({ theme }) =>
+    `${theme.borderStyle.dash} ${theme.neutral.border.default}`};
+`;

--- a/fe/src/features/newIssue/components/NewIssueActionButtons.tsx
+++ b/fe/src/features/newIssue/components/NewIssueActionButtons.tsx
@@ -1,0 +1,23 @@
+import styled from '@emotion/styled';
+import Button from '@/shared/components/Button';
+import XIcon from '@/assets/icons/xSquare.svg?react';
+
+export default function NewIssueActionButtons() {
+  return (
+    <ButtonGroup>
+      <Button variant="ghost" size="medium" icon={<XIcon />}>
+        작성 취소
+      </Button>
+      {/* TODO 조건에 따라 button 활성화 */}
+      <Button size="medium" disabled={true}>
+        완료
+      </Button>
+    </ButtonGroup>
+  );
+}
+
+const ButtonGroup = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 32px;
+`;

--- a/fe/src/features/newIssue/components/NewIssueActionButtons.tsx
+++ b/fe/src/features/newIssue/components/NewIssueActionButtons.tsx
@@ -2,14 +2,21 @@ import styled from '@emotion/styled';
 import Button from '@/shared/components/Button';
 import XIcon from '@/assets/icons/xSquare.svg?react';
 
-export default function NewIssueActionButtons() {
+interface NewIssueActionButtonsProps {
+  isSubmitDisabled: boolean;
+  onSubmit: () => void;
+}
+
+export default function NewIssueActionButtons({
+  isSubmitDisabled,
+  onSubmit,
+}: NewIssueActionButtonsProps) {
   return (
     <ButtonGroup>
       <Button variant="ghost" size="medium" icon={<XIcon />}>
         작성 취소
       </Button>
-      {/* TODO 조건에 따라 button 활성화 */}
-      <Button size="medium" disabled={true}>
+      <Button size="medium" disabled={isSubmitDisabled} onClick={onSubmit}>
         완료
       </Button>
     </ButtonGroup>

--- a/fe/src/features/newIssue/components/NewIssueForm.tsx
+++ b/fe/src/features/newIssue/components/NewIssueForm.tsx
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+import CommentInputSection from './CommentInputSection';
+import TitleInput from './TitleInput';
+
+interface NewIssueFormProps {
+  title: string;
+  onTitleChange: (value: string) => void;
+
+  content: string;
+  onContentChange: (value: string) => void;
+}
+
+export default function NewIssueForm({
+  title,
+  content,
+  onTitleChange,
+  onContentChange,
+}: NewIssueFormProps) {
+  return (
+    <FormSection>
+      <TitleInput value={title} onChange={onTitleChange} label="제목" />
+      <CommentInputSection value={content} onChange={onContentChange} />
+    </FormSection>
+  );
+}
+
+const FormSection = styled.section`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;

--- a/fe/src/features/newIssue/components/NewIssueFormSection.tsx
+++ b/fe/src/features/newIssue/components/NewIssueFormSection.tsx
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+
+export default function NewIssueFormSection() {
+  return <FormWrapper></FormWrapper>;
+}
+
+const FormWrapper = styled.main`
+  display: flex;
+  align-items: flex-start;
+  gap: 24px;
+`;

--- a/fe/src/features/newIssue/components/NewIssueFormSection.tsx
+++ b/fe/src/features/newIssue/components/NewIssueFormSection.tsx
@@ -1,10 +1,36 @@
 import styled from '@emotion/styled';
+import Profile from '@/shared/components/Profile';
+import IssueForm from './NewIssueForm';
 
-export default function NewIssueFormSection() {
-  return <FormWrapper></FormWrapper>;
+interface NewIssueFormSectionProps {
+  title: string;
+  onTitleChange: (value: string) => void;
+
+  content: string;
+  onContentChange: (value: string) => void;
 }
 
-const FormWrapper = styled.main`
+export default function NewIssueFormSection({
+  title,
+  onTitleChange,
+  content,
+  onContentChange,
+}: NewIssueFormSectionProps) {
+  return (
+    <MainWrapper>
+      <Profile size="md" />
+      <IssueForm
+        title={title}
+        content={content}
+        onTitleChange={onTitleChange}
+        onContentChange={onContentChange}
+      />
+      {/* sidebar */}
+    </MainWrapper>
+  );
+}
+
+const MainWrapper = styled.main`
   display: flex;
   align-items: flex-start;
   gap: 24px;

--- a/fe/src/features/newIssue/components/NewIssueHeader.tsx
+++ b/fe/src/features/newIssue/components/NewIssueHeader.tsx
@@ -1,0 +1,23 @@
+import styled from '@emotion/styled';
+
+export default function NewIssueHeader() {
+  return (
+    <HeaderWrapper>
+      <Title>새로운 이슈 작성</Title>
+    </HeaderWrapper>
+  );
+}
+
+const HeaderWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const Title = styled.h1`
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+
+  color: ${({ theme }) => theme.neutral.text.strong};
+  ${({ theme }) => theme.typography.displayBold32};
+`;

--- a/fe/src/features/newIssue/components/TitleInput.tsx
+++ b/fe/src/features/newIssue/components/TitleInput.tsx
@@ -1,0 +1,63 @@
+import styled from '@emotion/styled';
+import { useState } from 'react';
+
+interface TitleInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  label: string;
+}
+
+export default function TitleInput({
+  value,
+  onChange,
+  label,
+}: TitleInputProps) {
+  const [isFocused, setIsFocused] = useState(false);
+
+  return (
+    <Wrapper>
+      <LabelAbove isFloating={isFocused || !!value}>{label}</LabelAbove>
+      <StyledInput
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+      />
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  position: relative;
+  width: 100%;
+  height: 56px;
+  border-radius: ${({ theme }) => theme.radius.medium};
+  background-color: ${({ theme }) => theme.neutral.surface.bold};
+`;
+
+const LabelAbove = styled.label<{ isFloating: boolean }>`
+  position: absolute;
+  left: 16px;
+  top: ${({ isFloating }) => (isFloating ? '8px' : '50%')};
+  transform: ${({ isFloating }) => (isFloating ? 'none' : 'translateY(-50%)')};
+  ${({ theme, isFloating }) =>
+    isFloating
+      ? theme.typography.displayMedium12
+      : theme.typography.displayMedium16};
+  color: ${({ theme }) => theme.neutral.text.weak};
+  transition: all 0.2s ease;
+`;
+
+const StyledInput = styled.input`
+  all: unset;
+  width: 100%;
+  height: 100%;
+  padding: 24px 16px 8px;
+  box-sizing: border-box;
+  color: ${({ theme }) => theme.neutral.text.strong};
+  ${({ theme }) => theme.typography.displayMedium16};
+
+  &::placeholder {
+    color: transparent;
+  }
+`;

--- a/fe/src/pages/NewIssuePage.tsx
+++ b/fe/src/pages/NewIssuePage.tsx
@@ -8,6 +8,15 @@ import NewIssueFormSection from '@/features/newIssue/components/NewIssueFormSect
 export default function NewIssuePage() {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
+
+  function isTitleEmpty(title: string) {
+    return title.trim() === '';
+  }
+
+  function handleCreateIssue() {
+    //TODO 이슈 생성 로직 추가
+  }
+
   return (
     <VerticalStack>
       <NewIssueHeader />
@@ -19,7 +28,10 @@ export default function NewIssuePage() {
         onContentChange={setContent}
       />
       <Divider />
-      <NewIssueActionButtons />
+      <NewIssueActionButtons
+        isSubmitDisabled={isTitleEmpty(title)}
+        onSubmit={handleCreateIssue}
+      />
     </VerticalStack>
   );
 }

--- a/fe/src/pages/NewIssuePage.tsx
+++ b/fe/src/pages/NewIssuePage.tsx
@@ -1,15 +1,23 @@
+import { useState } from 'react';
 import VerticalStack from '@/layouts/VerticalStack';
 import Divider from '@/shared/components/Divider';
+import NewIssueActionButtons from '@/features/newIssue/components/NewIssueActionButtons';
 import NewIssueHeader from '@/features/newIssue/components/NewIssueHeader';
 import NewIssueFormSection from '@/features/newIssue/components/NewIssueFormSection';
-import NewIssueActionButtons from '@/features/newIssue/components/NewIssueActionButtons';
 
 export default function NewIssuePage() {
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
   return (
     <VerticalStack>
       <NewIssueHeader />
       <Divider />
-      <NewIssueFormSection />
+      <NewIssueFormSection
+        title={title}
+        onTitleChange={setTitle}
+        content={content}
+        onContentChange={setContent}
+      />
       <Divider />
       <NewIssueActionButtons />
     </VerticalStack>

--- a/fe/src/pages/NewIssuePage.tsx
+++ b/fe/src/pages/NewIssuePage.tsx
@@ -1,3 +1,17 @@
+import VerticalStack from '@/layouts/VerticalStack';
+import Divider from '@/shared/components/Divider';
+import NewIssueHeader from '@/features/newIssue/components/NewIssueHeader';
+import NewIssueFormSection from '@/features/newIssue/components/NewIssueFormSection';
+import NewIssueActionButtons from '@/features/newIssue/components/NewIssueActionButtons';
+
 export default function NewIssuePage() {
-  return <div>📝 NewIssuePage (이슈 생성 페이지 - 임시)</div>;
+  return (
+    <VerticalStack>
+      <NewIssueHeader />
+      <Divider />
+      <NewIssueFormSection />
+      <Divider />
+      <NewIssueActionButtons />
+    </VerticalStack>
+  );
 }


### PR DESCRIPTION
## 📌 PR 제목

[Feature] 이슈 생성 페이지 기본 구조 및 입력 필드 구현

## ✅ 작업 요약

- [x] 이슈 생성 페이지의 기본 구조를 Header / Main / Footer로 분리하여 구성
- [x] 이슈 제목과 내용 입력 필드 구현
- [x] grip.svg 아이콘을 이슈 생성 UI에 사용하기 위해 추가
- [x] 개발 환경에서 Node.js 타입 지원을 위해 `@types/node`를 devDependencies에 추가

### UI 기능
- [x] 사용자가 입력 시 글자 수가 2초간 나타났다 사라지는 기능 구현
- [x] 입력 필드에 focus 시 placeholder가 작게 노출되는 인터랙션 추가
- [x] 버튼 활성화 로직 구현: 제목이 입력된 경우에만 버튼이 활성화되도록 조건부 렌더링 적용

## ✅ 테스트 확인

- [x] 기본 UI 동작은 브라우저에서 수동 확인 완료

### 추후 구현 사항

- **사이드바 구성 보류**
  - 담당자, 라벨, 마일스톤 등의 사이드바 영역은 추후 드롭다운 및 데이터 패칭 기능이 구현될 때 함께 추가할 예정
  - 지금은 구조만 구성하고, 기능이 확정된 이후 개발 편의를 위해 별도 분리하여 적용할 계획

## 🧠 회고/고민

### 1. 인터랙션 처리 고민

- 글자 수를 일정 시간만 보여주기 위한 `setTimeout` 로직에서 불필요한 재실행 방지를 위해 `ref`를 활용한 debounce 처리를 고민함
- 최적화와 가독성 측면에서 로직 분리 및 타이머 해제를 신경 써 구현

### 2. 입력 필드 포커스 스타일

- 포커스 시 placeholder가 축소되는 효과를 자연스럽게 만들기 위해 CSS 트랜지션과 focus 상태를 조합
- 디자인 시스템에서 일관성을 유지하며 사용자 경험을 해치지 않도록 배경색 및 box-shadow 설정을 함께 적용

### 3. 조건부 버튼 활성화

- 입력값 유효성 검사 여부를 어디서 처리할지 고민함. 현재는 프론트 단에서 최소 조건(제목 존재)을 기준으로 단순 활성화
- 추후 validation 로직이 추가될 경우 해당 조건을 통합 관리하는 방식으로 확장성 고려


closes #58 #56