### PR TITLE
[Feat] 새로운 이슈 작성 상태 관리 로직 및 폼 구성 도입

### DIFF
--- a/frontend/src/features/newIssue/components/NewIssueActionButtons.tsx
+++ b/frontend/src/features/newIssue/components/NewIssueActionButtons.tsx
@@ -5,15 +5,17 @@ import XIcon from '@/assets/icons/xSquare.svg?react';
 interface NewIssueActionButtonsProps {
   isSubmitDisabled: boolean;
   onSubmit: () => void;
+  onCancel: () => void;
 }
 
 export default function NewIssueActionButtons({
   isSubmitDisabled,
   onSubmit,
+  onCancel,
 }: NewIssueActionButtonsProps) {
   return (
     <ButtonGroup>
-      <Button variant="ghost" size="medium" icon={<XIcon />}>
+      <Button variant="ghost" size="medium" icon={<XIcon />} onClick={onCancel}>
         작성 취소
       </Button>
       <Button size="medium" disabled={isSubmitDisabled} onClick={onSubmit}>

--- a/frontend/src/features/newIssue/components/NewIssueFormSection.tsx
+++ b/frontend/src/features/newIssue/components/NewIssueFormSection.tsx
@@ -8,6 +8,15 @@ interface NewIssueFormSectionProps {
 
   content: string;
   onContentChange: (value: string) => void;
+
+  milestoneId: number | null;
+  onMilestoneChange: (id: number | null) => void;
+
+  selectedLabelIds: number[];
+  onToggleLabel: (id: number) => void;
+
+  selectedAssigneeIds: number[];
+  onToggleAssignee: (id: number) => void;
 }
 
 export default function NewIssueFormSection({

--- a/frontend/src/features/newIssue/hooks/useNewIssueForm.ts
+++ b/frontend/src/features/newIssue/hooks/useNewIssueForm.ts
@@ -1,0 +1,22 @@
+import { useReducer } from 'react';
+import {
+  newIssueFormReducer,
+  type NewIssueState,
+} from '../reducers/newIssueFormReducer';
+
+export const initialNewIssueFormState: NewIssueState = {
+  title: '',
+  content: '',
+  milestoneId: null,
+  labelIds: [],
+  assigneeIds: [],
+};
+
+export function useNewIssueForm() {
+  const [state, dispatch] = useReducer(
+    newIssueFormReducer,
+    initialNewIssueFormState,
+  );
+
+  return { state, dispatch };
+}

--- a/frontend/src/features/newIssue/reducers/newIssueFormReducer.ts
+++ b/frontend/src/features/newIssue/reducers/newIssueFormReducer.ts
@@ -1,0 +1,50 @@
+import { initialNewIssueFormState } from '../hooks/useNewIssueForm';
+
+export type NewIssueState = {
+  title: string;
+  content: string;
+  milestoneId: number | null;
+  labelIds: number[];
+  assigneeIds: number[];
+};
+
+export type Action =
+  | { type: 'SET_TITLE'; payload: string }
+  | { type: 'SET_CONTENT'; payload: string }
+  | { type: 'SET_MILESTONE'; payload: number | null }
+  | { type: 'TOGGLE_LABEL'; payload: number }
+  | { type: 'TOGGLE_ASSIGNEE'; payload: number }
+  | { type: 'RESET_FORM' };
+
+export function newIssueFormReducer(
+  state: NewIssueState,
+  action: Action,
+): NewIssueState {
+  switch (action.type) {
+    case 'SET_TITLE':
+      return { ...state, title: action.payload };
+    case 'SET_CONTENT':
+      return { ...state, content: action.payload };
+    case 'SET_MILESTONE':
+      return { ...state, milestoneId: action.payload };
+    case 'TOGGLE_LABEL':
+      return {
+        ...state,
+        labelIds: state.labelIds.includes(action.payload)
+          ? state.labelIds.filter(id => id !== action.payload)
+          : [...state.labelIds, action.payload],
+      };
+    case 'TOGGLE_ASSIGNEE':
+      return {
+        ...state,
+        assigneeIds: state.assigneeIds.includes(action.payload)
+          ? state.assigneeIds.filter(id => id !== action.payload)
+          : [...state.assigneeIds, action.payload],
+      };
+
+    case 'RESET_FORM':
+      return initialNewIssueFormState;
+    default:
+      return state;
+  }
+}

--- a/frontend/src/features/newIssue/types.ts
+++ b/frontend/src/features/newIssue/types.ts
@@ -1,0 +1,7 @@
+export interface NewIssueState {
+  title: string;
+  content: string | null;
+  milestoneId: number | null;
+  labelIds: number[];
+  assigneeIds: number[];
+}

--- a/frontend/src/features/newIssue/utils.ts
+++ b/frontend/src/features/newIssue/utils.ts
@@ -1,0 +1,25 @@
+import { type NewIssueState } from '@/features/newIssue/types';
+
+export function buildIssuePayload(form: NewIssueState) {
+  const payload: Record<string, unknown> = {
+    title: form.title.trim(),
+  };
+
+  if (form.content !== '') {
+    payload.content = form.content;
+  }
+
+  if (form.milestoneId !== null) {
+    payload.milestoneId = form.milestoneId;
+  }
+
+  if (form.labelIds.length > 0) {
+    payload.labelIds = form.labelIds;
+  }
+
+  if (form.assigneeIds.length > 0) {
+    payload.assigneeIds = form.assigneeIds;
+  }
+
+  return payload;
+}

--- a/frontend/src/pages/NewIssuePage.tsx
+++ b/frontend/src/pages/NewIssuePage.tsx
@@ -1,4 +1,5 @@
 import { useNewIssueForm } from '@/features/newIssue/hooks/useNewIssueForm';
+import { buildIssuePayload } from '@/features/newIssue/utils';
 import VerticalStack from '@/layouts/VerticalStack';
 import Divider from '@/shared/components/Divider';
 import NewIssueActionButtons from '@/features/newIssue/components/NewIssueActionButtons';
@@ -13,7 +14,10 @@ export default function NewIssuePage() {
   }
 
   function handleCreateIssue() {
-    //TODO 이슈 생성 로직 추가
+    const payload = buildIssuePayload(issueForm);
+    console.log('[POST] /api/v1/issues payload:', payload);
+
+    // TODO fetch/postIssue(payload)
   }
 
   return (

--- a/frontend/src/pages/NewIssuePage.tsx
+++ b/frontend/src/pages/NewIssuePage.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import { useNewIssueForm } from '@/features/newIssue/hooks/useNewIssueForm';
 import { buildIssuePayload } from '@/features/newIssue/utils';
 import VerticalStack from '@/layouts/VerticalStack';
@@ -7,7 +8,13 @@ import NewIssueHeader from '@/features/newIssue/components/NewIssueHeader';
 import NewIssueFormSection from '@/features/newIssue/components/NewIssueFormSection';
 
 export default function NewIssuePage() {
+  const navigate = useNavigate();
   const { state: issueForm, dispatch: updateIssueForm } = useNewIssueForm();
+
+  function handleCancel() {
+    updateIssueForm({ type: 'RESET_FORM' });
+    navigate('/');
+  }
 
   function isTitleEmpty(title: string) {
     return title.trim() === '';
@@ -50,6 +57,7 @@ export default function NewIssuePage() {
       <NewIssueActionButtons
         isSubmitDisabled={isTitleEmpty(issueForm.title)}
         onSubmit={handleCreateIssue}
+        onCancel={handleCancel}
       />
     </VerticalStack>
   );

--- a/frontend/src/pages/NewIssuePage.tsx
+++ b/frontend/src/pages/NewIssuePage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useNewIssueForm } from '@/features/newIssue/hooks/useNewIssueForm';
 import VerticalStack from '@/layouts/VerticalStack';
 import Divider from '@/shared/components/Divider';
 import NewIssueActionButtons from '@/features/newIssue/components/NewIssueActionButtons';
@@ -6,8 +6,7 @@ import NewIssueHeader from '@/features/newIssue/components/NewIssueHeader';
 import NewIssueFormSection from '@/features/newIssue/components/NewIssueFormSection';
 
 export default function NewIssuePage() {
-  const [title, setTitle] = useState('');
-  const [content, setContent] = useState('');
+  const { state: issueForm, dispatch: updateIssueForm } = useNewIssueForm();
 
   function isTitleEmpty(title: string) {
     return title.trim() === '';
@@ -22,14 +21,30 @@ export default function NewIssuePage() {
       <NewIssueHeader />
       <Divider />
       <NewIssueFormSection
-        title={title}
-        onTitleChange={setTitle}
-        content={content}
-        onContentChange={setContent}
+        title={issueForm.title}
+        onTitleChange={val =>
+          updateIssueForm({ type: 'SET_TITLE', payload: val })
+        }
+        content={issueForm.content}
+        onContentChange={val =>
+          updateIssueForm({ type: 'SET_CONTENT', payload: val })
+        }
+        milestoneId={issueForm.milestoneId}
+        onMilestoneChange={id =>
+          updateIssueForm({ type: 'SET_MILESTONE', payload: id })
+        }
+        selectedLabelIds={issueForm.labelIds}
+        onToggleLabel={id =>
+          updateIssueForm({ type: 'TOGGLE_LABEL', payload: id })
+        }
+        selectedAssigneeIds={issueForm.assigneeIds}
+        onToggleAssignee={id =>
+          updateIssueForm({ type: 'TOGGLE_ASSIGNEE', payload: id })
+        }
       />
       <Divider />
       <NewIssueActionButtons
-        isSubmitDisabled={isTitleEmpty(title)}
+        isSubmitDisabled={isTitleEmpty(issueForm.title)}
         onSubmit={handleCreateIssue}
       />
     </VerticalStack>


### PR DESCRIPTION
## 📌 PR 제목  
[Feat] 새로운 이슈 작성 상태 관리 로직 및 폼 구성 도입

---

## ✅ 작업 요약

- [x] `useReducer` 기반으로 새로운 이슈 작성 상태 구조 정의
- [x] `newIssueFormReducer.ts` 파일 생성 및 `Action`, `State` 분리 설계
- [x] `useNewIssueForm` 커스텀 훅 생성 및 초기 상태 반환 처리
- [x] `NewIssueFormSection`에 각 필드 상태 및 변경 핸들러 명시적 전달
- [x] `buildIssuePayload` 유틸 함수 구현: 불필요한 필드는 서버로 전달하지 않도록 조건부 구성 처리
- [x] `handleCreateIssue` 함수 내부에서 payload 구성 및 출력 처리
- [x] 상태 리셋 시 `RESET_FORM` 액션 사용 가능하도록 설계

---

## ✅ 테스트 확인

- [x] 제목, 본문, 마일스톤, 라벨, 담당자 값이 `dispatch`로 정상 반영되는지 수동 확인
- [x] [완료] 버튼 클릭 시 payload가 올바르게 생성되는지 콘솔 출력으로 확인
- [x] 작성 취소 시 페이지 언마운트에 따라 상태 자동 초기화되는지 확인

---

### 주요 고민 및 해결과정

- `Zustand` 등의 전역 상태를 사용할지 고민했지만, 해당 폼은 **이슈 생성 페이지에서만 사용하는 일시적 상태**이므로 `useReducer`를 도입하는 것이 명확하고 안전한 구조라고 판단하였습니다.
- 상태를 `state`/`dispatch`로 그대로 넘길지, 명시적으로 각 prop으로 분리할지 고민했고, **컴포넌트의 응집도와 테스트 용이성**을 고려해 모든 필드를 분리하여 전달하도록 결정하였습니다.
- 백엔드 요구사항에 따라 **빈 값 또는 null 값은 필드 자체를 생략**해야 했기 때문에 `buildIssuePayload()` 유틸 함수로 payload 생성 로직을 추상화하였습니다. 이 함수는 조건부 필터링을 통해 **불필요한 필드 누락**을 깔끔하게 처리합니다. 이는 추후 payload 구조가 달려졌을 때 해당 유틸함수만 수정하면 되기에 유지보수에 용이합니다.

closes #128 