### PR TITLE
[Hotfix] User 및 BaseOption의 id 타입 number로 통일

### DIFF
--- a/frontend/src/features/user/types.ts
+++ b/frontend/src/features/user/types.ts
@@ -1,7 +1,7 @@
 export interface User {
-  id: string;
+  id: number;
   nickname: string;
-  profileImage: string | null;
+  profileImage: string;
 }
 
 export interface GetUsersResponse {

--- a/frontend/src/shared/components/DropdownPanel.tsx
+++ b/frontend/src/shared/components/DropdownPanel.tsx
@@ -4,7 +4,7 @@ import SelectedIcon from '@/assets/icons/checkOnCircle.svg?react';
 import UnselectedIcon from '@/assets/icons/checkOffCircle.svg?react';
 
 interface BaseOption {
-  id: string;
+  id: number;
   name: string;
   selected: boolean;
 }
@@ -13,7 +13,7 @@ interface DropdownPanelProps<
   T extends Record<string, unknown> = Record<string, unknown>,
 > {
   options: (BaseOption & T)[];
-  onSelect: (id: string) => void;
+  onSelect: (id: number) => void;
   renderOption?: (option: BaseOption & T) => React.ReactNode;
 }
 


### PR DESCRIPTION
## 📌 PR 제목

[Hotfix] User 및 BaseOption의 id 타입 number로 통일

## ✅ 작업 요약

- API 응답 명세에 맞춰 User와 BaseOption의 id 타입을 `string`에서 `number`로 변경
- 타입 변경으로 인해 영향을 받는 컴포넌트 및 로직 전반을 리팩토링하여 타입 불일치 오류 제거

## ✅ 테스트 확인

- [x] User 및 BaseOption 타입을 사용하는 모든 컴포넌트에서 타입 에러 미발생 확인
- [x] 브라우저에서 주요 기능 정상 동작 확인

closes #132 