### PR TITLE
[Feature] 댓글 생성 api 구현

### DIFF
--- a/backend/src/main/java/elbin_bank/issue_tracker/comment/application/command/CommentCommandService.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/comment/application/command/CommentCommandService.java
@@ -1,0 +1,23 @@
+package elbin_bank.issue_tracker.comment.application.command;
+
+import elbin_bank.issue_tracker.comment.domain.Comment;
+import elbin_bank.issue_tracker.comment.domain.CommentCommandRepository;
+import elbin_bank.issue_tracker.comment.presentation.command.dto.request.CommentCreateRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommentCommandService {
+
+    private final CommentCommandRepository commentCommandRepository;
+
+    public void createComment(CommentCreateRequestDto requestDto, Long id) {
+        long mockUserId = 1L; // todo: 로그인 구현 후 변경 예정
+
+        Comment comment = Comment.of(id, mockUserId, requestDto.content());
+
+        commentCommandRepository.save(comment);
+    }
+
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/comment/application/query/dto/CommentDto.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/comment/application/query/dto/CommentDto.java
@@ -1,12 +1,14 @@
 package elbin_bank.issue_tracker.comment.application.query.dto;
 
+import elbin_bank.issue_tracker.user.infrastructure.query.projection.UserProjection;
+
 import java.time.LocalDateTime;
 
-public record CommentsSummaryDto(
+public record CommentDto(
         Long id,
-        UserDto author,
+        UserProjection author,
         String content,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
-        ) {
+) {
 }

--- a/backend/src/main/java/elbin_bank/issue_tracker/comment/domain/Comment.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/comment/domain/Comment.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
 @Table("comment")
@@ -17,9 +16,13 @@ import org.springframework.data.relational.core.mapping.Table;
 public class Comment extends BaseEntity {
 
     @Id
-    private long id;
+    private Long id;
     private long issueId;
     private long userId;
     private String contents;
+
+    public static Comment of(long issueId, long userId, String contents) {
+        return new Comment(null, issueId, userId, contents); // id는 DB에서 생성
+    }
 
 }

--- a/backend/src/main/java/elbin_bank/issue_tracker/comment/domain/CommentCommandRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/comment/domain/CommentCommandRepository.java
@@ -1,9 +1,7 @@
 package elbin_bank.issue_tracker.comment.domain;
 
-import elbin_bank.issue_tracker.comment.presentation.command.dto.request.CommentCreateRequestDto;
-
 public interface CommentCommandRepository {
 
-    void save(CommentCreateRequestDto commentCreateRequestDto, long issueId);
+    void save(Comment comment);
 
 }

--- a/backend/src/main/java/elbin_bank/issue_tracker/comment/domain/CommentCommandRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/comment/domain/CommentCommandRepository.java
@@ -1,0 +1,9 @@
+package elbin_bank.issue_tracker.comment.domain;
+
+import elbin_bank.issue_tracker.comment.presentation.command.dto.request.CommentCreateRequestDto;
+
+public interface CommentCommandRepository {
+
+    void save(CommentCreateRequestDto commentCreateRequestDto, long issueId);
+
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/comment/infrastructure/command/JdbcCommentCommandRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/comment/infrastructure/command/JdbcCommentCommandRepository.java
@@ -1,0 +1,35 @@
+package elbin_bank.issue_tracker.comment.infrastructure.command;
+
+import elbin_bank.issue_tracker.comment.domain.CommentCommandRepository;
+import elbin_bank.issue_tracker.comment.presentation.command.dto.request.CommentCreateRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class JdbcCommentCommandRepository implements CommentCommandRepository {
+
+    private final NamedParameterJdbcTemplate jdbc;
+
+    @Override
+    public void save(CommentCreateRequestDto commentCreateRequestDto, long id) {
+        Long mockUserId = 1L; // todo: 로그인 구현 후 변경 예정
+
+        String sql = """
+                    INSERT INTO comment
+                      (issue_id, user_id, contents)
+                    VALUES
+                      (:issueId, :userId, :contents)
+                """;
+
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("issueId", id)
+                .addValue("userId", mockUserId)
+                .addValue("contents", commentCreateRequestDto.content());
+
+        jdbc.update(sql, params);
+    }
+
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/comment/infrastructure/command/JdbcCommentCommandRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/comment/infrastructure/command/JdbcCommentCommandRepository.java
@@ -1,7 +1,7 @@
 package elbin_bank.issue_tracker.comment.infrastructure.command;
 
+import elbin_bank.issue_tracker.comment.domain.Comment;
 import elbin_bank.issue_tracker.comment.domain.CommentCommandRepository;
-import elbin_bank.issue_tracker.comment.presentation.command.dto.request.CommentCreateRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -14,9 +14,7 @@ public class JdbcCommentCommandRepository implements CommentCommandRepository {
     private final NamedParameterJdbcTemplate jdbc;
 
     @Override
-    public void save(CommentCreateRequestDto commentCreateRequestDto, long id) {
-        Long mockUserId = 1L; // todo: 로그인 구현 후 변경 예정
-
+    public void save(Comment comment) {
         String sql = """
                     INSERT INTO comment
                       (issue_id, user_id, contents)
@@ -25,9 +23,9 @@ public class JdbcCommentCommandRepository implements CommentCommandRepository {
                 """;
 
         MapSqlParameterSource params = new MapSqlParameterSource()
-                .addValue("issueId", id)
-                .addValue("userId", mockUserId)
-                .addValue("contents", commentCreateRequestDto.content());
+                .addValue("issueId", comment.getIssueId())
+                .addValue("userId", comment.getUserId())
+                .addValue("contents", comment.getContents());
 
         jdbc.update(sql, params);
     }

--- a/backend/src/main/java/elbin_bank/issue_tracker/comment/infrastructure/query/JdbcCommentsQueryRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/comment/infrastructure/query/JdbcCommentsQueryRepository.java
@@ -1,16 +1,13 @@
 package elbin_bank.issue_tracker.comment.infrastructure.query;
 
-import elbin_bank.issue_tracker.comment.application.query.dto.UserDto;
-import elbin_bank.issue_tracker.comment.domain.Comment;
 import elbin_bank.issue_tracker.comment.application.query.CommentsQueryRepository;
-import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import elbin_bank.issue_tracker.comment.infrastructure.query.projection.CommentProjection;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @Repository
 public class JdbcCommentsQueryRepository implements CommentsQueryRepository {
@@ -22,42 +19,20 @@ public class JdbcCommentsQueryRepository implements CommentsQueryRepository {
     }
 
     @Override
-    public List<Comment> findByIssueId(Long issueId) {
-
-        String sql = "SELECT id, issue_id, user_id, contents, created_at, updated_at FROM comment WHERE issue_id = :issueId";
+    public List<CommentProjection> findByIssueId(Long issueId) {
+        String sql = "SELECT id, user_id, contents, created_at, updated_at FROM comment WHERE issue_id = :issueId";
 
         MapSqlParameterSource params = new MapSqlParameterSource()
                 .addValue("issueId", issueId);
 
-        return jdbc.query(sql, params, BeanPropertyRowMapper.newInstance(Comment.class));
+        RowMapper<CommentProjection> rowMapper = (rs, rowNum) -> new CommentProjection(
+                rs.getLong("id"),
+                rs.getLong("user_id"),
+                rs.getString("contents"),
+                rs.getTimestamp("created_at").toLocalDateTime(),
+                rs.getTimestamp("updated_at").toLocalDateTime()
+        );
+
+        return jdbc.query(sql, params, rowMapper);
     }
-
-    @Override
-    public Map<Long, UserDto> findUsersByIds(List<Long> userIds) {
-        if (userIds == null || userIds.isEmpty()) {
-            return Map.of();
-        }
-
-        String sql = """
-                SELECT id, nickname, profile_image_url
-                FROM user
-                WHERE id IN (:Ids)
-                """;
-
-        var params = new MapSqlParameterSource("Ids", userIds);
-
-        return jdbc.query(sql, params, rs -> {
-            Map<Long, UserDto> result = new HashMap<>();
-            while (rs.next()) {
-                Long id = rs.getLong("id");
-                String nickname = rs.getString("nickname");
-                String profileImageUrl = rs.getString("profile_image_url");
-
-                UserDto dto = new UserDto(id, nickname, profileImageUrl);
-                result.put(id, dto);
-            }
-            return result;
-        });
-    }
-
 }

--- a/backend/src/main/java/elbin_bank/issue_tracker/comment/presentation/command/CommentCommandController.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/comment/presentation/command/CommentCommandController.java
@@ -1,0 +1,25 @@
+package elbin_bank.issue_tracker.comment.presentation.command;
+
+import elbin_bank.issue_tracker.comment.application.query.CommentsQueryRepository;
+import elbin_bank.issue_tracker.comment.domain.CommentCommandRepository;
+import elbin_bank.issue_tracker.comment.presentation.command.dto.request.CommentCreateRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/issues")
+@RequiredArgsConstructor
+public class CommentCommandController {
+
+    private final CommentCommandRepository commentCommandRepository;
+
+    @PostMapping(s)
+    public ResponseEntity<Void> createComment(@RequestBody CommentCreateRequestDto commentCreateRequestDto, @PathVariable Long id, String s){
+        commentCommandRepository.save(commentCreateRequestDto, id);
+
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/comment/presentation/command/CommentCommandController.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/comment/presentation/command/CommentCommandController.java
@@ -1,6 +1,6 @@
 package elbin_bank.issue_tracker.comment.presentation.command;
 
-import elbin_bank.issue_tracker.comment.domain.CommentCommandRepository;
+import elbin_bank.issue_tracker.comment.application.command.CommentCommandService;
 import elbin_bank.issue_tracker.comment.presentation.command.dto.request.CommentCreateRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -12,11 +12,11 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class CommentCommandController {
 
-    private final CommentCommandRepository commentCommandRepository;
+    private final CommentCommandService commentCommandService;
 
     @PostMapping("/{id}/comments")
-    public ResponseEntity<Void> createComment(@RequestBody CommentCreateRequestDto commentCreateRequestDto, @PathVariable Long id){
-        commentCommandRepository.save(commentCreateRequestDto, id);
+    public ResponseEntity<Void> createComment(@RequestBody CommentCreateRequestDto commentCreateRequestDto, @PathVariable Long id) {
+        commentCommandService.createComment(commentCreateRequestDto, id);
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }

--- a/backend/src/main/java/elbin_bank/issue_tracker/comment/presentation/command/CommentCommandController.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/comment/presentation/command/CommentCommandController.java
@@ -1,6 +1,5 @@
 package elbin_bank.issue_tracker.comment.presentation.command;
 
-import elbin_bank.issue_tracker.comment.application.query.CommentsQueryRepository;
 import elbin_bank.issue_tracker.comment.domain.CommentCommandRepository;
 import elbin_bank.issue_tracker.comment.presentation.command.dto.request.CommentCreateRequestDto;
 import lombok.RequiredArgsConstructor;
@@ -15,8 +14,8 @@ public class CommentCommandController {
 
     private final CommentCommandRepository commentCommandRepository;
 
-    @PostMapping(s)
-    public ResponseEntity<Void> createComment(@RequestBody CommentCreateRequestDto commentCreateRequestDto, @PathVariable Long id, String s){
+    @PostMapping("/{id}/comments")
+    public ResponseEntity<Void> createComment(@RequestBody CommentCreateRequestDto commentCreateRequestDto, @PathVariable Long id){
         commentCommandRepository.save(commentCreateRequestDto, id);
 
         return ResponseEntity.status(HttpStatus.CREATED).build();

--- a/backend/src/main/java/elbin_bank/issue_tracker/comment/presentation/command/dto/request/CommentCreateRequestDto.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/comment/presentation/command/dto/request/CommentCreateRequestDto.java
@@ -1,0 +1,6 @@
+package elbin_bank.issue_tracker.comment.presentation.command.dto.request;
+
+public record CommentCreateRequestDto(
+        String content
+) {
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/comment/presentation/query/CommentQueryController.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/comment/presentation/query/CommentQueryController.java
@@ -1,7 +1,8 @@
-package elbin_bank.issue_tracker.comment.presentation;
+package elbin_bank.issue_tracker.comment.presentation.query;
 
 import elbin_bank.issue_tracker.comment.application.query.CommentQueryService;
 import elbin_bank.issue_tracker.comment.application.query.dto.CommentsResponseDto;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -10,19 +11,16 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/issues")
+@RequiredArgsConstructor
 public class CommentQueryController {
 
     private final CommentQueryService commentQueryService;
 
-    public CommentQueryController(CommentQueryService commentQueryService) {
-        this.commentQueryService = commentQueryService;
-    }
-
     @GetMapping("/{id}/comments")
     public ResponseEntity<CommentsResponseDto> getComments(@PathVariable long id) {
-        try{
+        try {
             return ResponseEntity.ok(commentQueryService.findByIssueId(id));
-        }catch (IllegalArgumentException e){
+        } catch (IllegalArgumentException e) {
             return ResponseEntity.notFound().build();
         }
     }


### PR DESCRIPTION
## ✅ 작업 요약

댓글 생성 api 구현 

postman을 통한 api 정상 동작 확인 

## 🧠 회고/고민

Request를 통해 받은 정보들을 dto로 변환하기 위해 service layer를 만들어야 할까 했지만 만들지 않았습니다.
dto 변환을 위해 service layer를 만드는 것은 너무 과도한 역할 분리라 생각해 repository layer에서 받은 정보를 db schema에 맞게 저장하도록 하였습니다.
아직 로그인 부분을 구현하지 않아 service layer가 필요없게 된 거 같은데, 로그인 부분이 구현되어지면 그 때 추가하도록 하겠습니다.  