### PR TITLE
[Refactor] 마일스톤 타입 정비 및 사이드바 통합 적용  

### DIFF
--- a/frontend/src/features/issue/components/AssigneeSection.tsx
+++ b/frontend/src/features/issue/components/AssigneeSection.tsx
@@ -1,0 +1,89 @@
+import styled from '@emotion/styled';
+import { useUsers } from '@/features/user/hooks/useUsers';
+import { type User } from '@/features/user/types';
+import Profile from '@/shared/components/Profile';
+import Dropdown from '@/shared/components/Dropdown';
+import DropdownPanel from '@/shared/components/DropdownPanel';
+
+interface AssigneeSectionProps {
+  selectedAssigneeIds: number[];
+  onToggleAssignee: (id: number) => void;
+}
+
+export default function AssigneeSection({
+  selectedAssigneeIds,
+  onToggleAssignee,
+}: AssigneeSectionProps) {
+  const { users } = useUsers();
+
+  const assigneeOptions = users.map((user: User) => ({
+    id: user.id,
+    name: user.nickname,
+    imageUrl: user.profileImage,
+    selected: selectedAssigneeIds.includes(user.id),
+  }));
+
+  const selectedAssignees = users.filter(user =>
+    selectedAssigneeIds.includes(user.id),
+  );
+
+  return (
+    <Section>
+      <Dropdown label="담당자">
+        <DropdownPanel<{ imageUrl: string }>
+          options={assigneeOptions}
+          onSelect={onToggleAssignee}
+          renderOption={option => (
+            <UserInfo>
+              <UserImage src={option.imageUrl} />
+              <span>{option.name}</span>
+            </UserInfo>
+          )}
+        />
+      </Dropdown>
+      {selectedAssigneeIds.length > 0 && (
+        <SectionList>
+          {selectedAssignees.map(assignee => (
+            <Profile
+              key={assignee.id}
+              size="sm"
+              name={assignee.nickname}
+              imageUrl={assignee.profileImage}
+            />
+          ))}
+        </SectionList>
+      )}
+    </Section>
+  );
+}
+
+const Section = styled.div<{ noDivider?: boolean }>`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 32px;
+`;
+
+const UserInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const UserImage = styled.img`
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  object-fit: cover;
+`;
+
+const SectionList = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  ${({ theme }) => theme.typography.availableMedium12};
+  color: ${({ theme }) => theme.neutral.text.strong};
+`;

--- a/frontend/src/features/issue/components/IssueSidebar.tsx
+++ b/frontend/src/features/issue/components/IssueSidebar.tsx
@@ -1,47 +1,43 @@
 import styled from '@emotion/styled';
-import { getAccessibleLabelStyle } from '@/shared/utils/color';
-import Profile from '@/shared/components/Profile';
-import { type Assignee, type Milestone, type Label } from '../types/issue';
-import SidebarSection from './SidebarSection';
-import MilestoneProgressBar from '@/shared/components/MilestoneProgressBar';
+import AssigneeSection from './AssigneeSection';
+import LabelSection from './LabelSection';
+import MilestoneSection from './MilestoneSection';
 
-interface SidebarProps {
-  assignees: Assignee[];
-  labels: Label[];
-  milestone: Milestone | null;
+interface IssueSidebarProps {
+  selectedAssigneeIds: number[];
+  onToggleAssignee: (id: number) => void;
+
+  selectedLabelIds: number[];
+  onToggleLabel: (id: number) => void;
+
+  selectedMilestoneId: number | null;
+  onSelectMilestone: (id: number) => void;
 }
 
 export default function IssueSidebar({
-  assignees,
-  labels,
-  milestone,
-}: SidebarProps) {
+  selectedAssigneeIds,
+  onToggleAssignee,
+  selectedLabelIds,
+  onToggleLabel,
+  selectedMilestoneId,
+  onSelectMilestone,
+}: IssueSidebarProps) {
   return (
     <SidebarWrapper>
-      <SidebarSection title="담당자" isEmpty={assignees.length === 0}>
-        <SectionList>
-          {assignees.map(assignee => (
-            <Profile
-              key={assignee.id}
-              size="sm"
-              name={assignee.nickname}
-              imageUrl={assignee.profileImage}
-            />
-          ))}
-        </SectionList>
-      </SidebarSection>
+      <AssigneeSection
+        selectedAssigneeIds={selectedAssigneeIds}
+        onToggleAssignee={onToggleAssignee}
+      />
 
-      <SidebarSection title="레이블" isEmpty={assignees.length === 0}>
-        <LabelList>{renderLabelList(labels)}</LabelList>
-      </SidebarSection>
+      <LabelSection
+        selectedLabelIds={selectedLabelIds}
+        onToggleLabel={onToggleLabel}
+      />
 
-      <SidebarSection title="마일스톤" isEmpty={!milestone}>
-        {milestone && (
-          <MilestoneProgressBar percentage={milestone.progressRate}>
-            <MilestoneLabel>{milestone.name}</MilestoneLabel>
-          </MilestoneProgressBar>
-        )}
-      </SidebarSection>
+      <MilestoneSection
+        selectedMilestoneId={selectedMilestoneId}
+        onSelectMilestone={onSelectMilestone}
+      />
     </SidebarWrapper>
   );
 }
@@ -61,62 +57,3 @@ const SidebarWrapper = styled.div`
     border-bottom: 1px solid ${({ theme }) => theme.neutral.border.default};
   }
 `;
-
-const LabelList = styled.div`
-  width: 100%;
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  gap: 4px;
-
-  ${({ theme }) => theme.typography.availableMedium12};
-  color: ${({ theme }) => theme.neutral.text.strong};
-`;
-
-const SectionList = styled.div`
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-
-  ${({ theme }) => theme.typography.availableMedium12};
-  color: ${({ theme }) => theme.neutral.text.strong};
-`;
-
-const MilestoneLabel = styled.span`
-  ${({ theme }) => theme.typography.displayMedium12};
-  color: ${({ theme }) => theme.neutral.text.strong};
-`;
-
-//TODO 공용 라벨 컴포넌트 분리
-interface LabelTagProps {
-  backgroundColor: string;
-  borderColor: string;
-  color: string;
-}
-
-const LabelTag = styled.span<LabelTagProps>`
-  padding: 4px 9px;
-  border-radius: ${({ theme }) => theme.radius.medium};
-  color: ${({ color }) => color};
-  background-color: ${({ backgroundColor }) => backgroundColor};
-  border: 1px solid ${({ borderColor }) => borderColor};
-  ${({ theme }) => theme.typography.displayMedium12};
-`;
-
-//TODO 공용 분리
-function renderLabelList(labels: Label[]) {
-  return labels.map(label => {
-    const { textColor, borderColor } = getAccessibleLabelStyle(label.color);
-    return (
-      <LabelTag
-        key={label.id}
-        backgroundColor={label.color}
-        borderColor={borderColor}
-        color={textColor}
-      >
-        {label.name}
-      </LabelTag>
-    );
-  });
-}

--- a/frontend/src/features/issue/components/LabelSection.tsx
+++ b/frontend/src/features/issue/components/LabelSection.tsx
@@ -1,0 +1,113 @@
+import styled from '@emotion/styled';
+import { useLabels } from '@/features/label/hooks/useLabels';
+import { type Label } from '../../label/types';
+import { getAccessibleLabelStyle } from '@/shared/utils/color';
+import Dropdown from '@/shared/components/Dropdown';
+import DropdownPanel from '@/shared/components/DropdownPanel';
+
+interface LabelSectionProps {
+  selectedLabelIds: number[];
+  onToggleLabel: (id: number) => void;
+}
+
+export default function LabelSection({
+  selectedLabelIds,
+  onToggleLabel,
+}: LabelSectionProps) {
+  const { labels } = useLabels();
+
+  const LabelOptions = labels.map((label: Label) => ({
+    id: label.id,
+    name: label.name,
+    color: label.color,
+    selected: selectedLabelIds.includes(label.id),
+  }));
+
+  const selectedLabels = labels.filter(label =>
+    selectedLabelIds.includes(label.id),
+  );
+
+  return (
+    <Section>
+      <Dropdown label="레이블">
+        <DropdownPanel<{ color: string }>
+          options={LabelOptions}
+          onSelect={onToggleLabel}
+          renderOption={option => (
+            <LabelInfo>
+              <ColorDot style={{ backgroundColor: option.color }} />
+              <span>{option.name}</span>
+            </LabelInfo>
+          )}
+        />
+      </Dropdown>
+      {selectedLabelIds.length > 0 && (
+        <LabelList>{renderLabelList(selectedLabels)}</LabelList>
+      )}
+    </Section>
+  );
+}
+
+const Section = styled.div<{ noDivider?: boolean }>`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 32px;
+`;
+
+//TODO 공용 라벨 컴포넌트 분리
+interface LabelTagProps {
+  backgroundColor: string;
+  borderColor: string;
+  color: string;
+}
+
+const LabelTag = styled.span<LabelTagProps>`
+  padding: 4px 9px;
+  border-radius: ${({ theme }) => theme.radius.medium};
+  color: ${({ color }) => color};
+  background-color: ${({ backgroundColor }) => backgroundColor};
+  border: 1px solid ${({ borderColor }) => borderColor};
+  ${({ theme }) => theme.typography.displayMedium12};
+`;
+
+const LabelInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const ColorDot = styled.div`
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+`;
+
+const LabelList = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 4px;
+
+  ${({ theme }) => theme.typography.availableMedium12};
+  color: ${({ theme }) => theme.neutral.text.strong};
+`;
+
+//TODO 공용 분리
+function renderLabelList(labels: Label[]) {
+  return labels.map(label => {
+    const { textColor, borderColor } = getAccessibleLabelStyle(label.color);
+    return (
+      <LabelTag
+        key={label.id}
+        backgroundColor={label.color}
+        borderColor={borderColor}
+        color={textColor}
+      >
+        {label.name}
+      </LabelTag>
+    );
+  });
+}

--- a/frontend/src/features/issue/components/MilestoneSection.tsx
+++ b/frontend/src/features/issue/components/MilestoneSection.tsx
@@ -1,0 +1,72 @@
+import styled from '@emotion/styled';
+import type { MilestoneDetail } from '@/features/milestone/types';
+import useMilestones from '@/features/milestone/hooks/useMilestones';
+import Dropdown from '@/shared/components/Dropdown';
+import DropdownPanel from '@/shared/components/DropdownPanel';
+import MilestoneProgressBar from '@/shared/components/MilestoneProgressBar';
+
+interface MilestoneSectionProps {
+  selectedMilestoneId: number | null;
+  onSelectMilestone: (id: number) => void;
+}
+
+export default function MilestoneSection({
+  selectedMilestoneId,
+  onSelectMilestone,
+}: MilestoneSectionProps) {
+  const { milestones } = useMilestones();
+
+  const milestoneOptions = milestones.map((milestone: MilestoneDetail) => ({
+    id: milestone.id,
+    name: milestone.title,
+    progressRate: milestone.progressRate,
+    selected: selectedMilestoneId === milestone.id,
+  }));
+
+  const selectedMilestone = milestones.find(
+    (milestone: MilestoneDetail) => selectedMilestoneId === milestone.id,
+  );
+
+  return (
+    <Section>
+      <Dropdown label="마엘스톤">
+        <DropdownPanel<{ progressRate: number }>
+          options={milestoneOptions}
+          onSelect={onSelectMilestone}
+          renderOption={option => <span>{option.name}</span>}
+        />
+      </Dropdown>
+
+      {selectedMilestone && (
+        <SectionList>
+          <MilestoneProgressBar percentage={selectedMilestone.progressRate}>
+            <MilestoneLabel>{selectedMilestone.title}</MilestoneLabel>
+          </MilestoneProgressBar>
+        </SectionList>
+      )}
+    </Section>
+  );
+}
+
+const Section = styled.div<{ noDivider?: boolean }>`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 32px;
+`;
+
+const SectionList = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  ${({ theme }) => theme.typography.availableMedium12};
+  color: ${({ theme }) => theme.neutral.text.strong};
+`;
+
+const MilestoneLabel = styled.span`
+  ${({ theme }) => theme.typography.displayMedium12};
+  color: ${({ theme }) => theme.neutral.text.strong};
+`;

--- a/frontend/src/features/issue/types/issue.ts
+++ b/frontend/src/features/issue/types/issue.ts
@@ -1,11 +1,8 @@
-export type IssueStatus = 'open' | 'closed';
+import type { Label } from '@/features/label/types';
+import type { User } from '@/features/user/types';
+import type { MilestoneDetail } from '@/features/milestone/types';
 
-export interface Label {
-  id: number;
-  name: string;
-  color: string;
-  description: string | null;
-}
+export type IssueStatus = 'open' | 'closed';
 
 export interface Issue {
   id: number;
@@ -25,19 +22,7 @@ export interface IssuesResponse {
   closeCount: number;
 }
 
-export interface Milestone {
-  id: number;
-  name: string;
-  progressRate: number;
-}
-
 export interface Assignee {
-  id: number;
-  nickname: string;
-  profileImage: string;
-}
-
-export interface Author {
   id: number;
   nickname: string;
   profileImage: string;
@@ -45,11 +30,11 @@ export interface Author {
 
 export interface IssueDetailResponse {
   id: number;
-  author: Author;
+  author: User;
   title: string;
   content: string | null;
   labels: Label[];
-  milestone: Milestone | null;
+  milestone: MilestoneDetail | null;
   assignees: Assignee[];
   isClosed: boolean;
   createdAt: string;

--- a/frontend/src/features/milestone/api/getMilestones.ts
+++ b/frontend/src/features/milestone/api/getMilestones.ts
@@ -1,0 +1,23 @@
+import { API } from '@/shared/constants/api';
+import { type GetMilestonesResponse } from '../types';
+
+export default async function getMilestones(): Promise<GetMilestonesResponse> {
+  const res = await fetch(`${API.MILESTONES}`);
+
+  const statusCodeHandler: Record<
+    number,
+    () => Promise<GetMilestonesResponse>
+  > = {
+    200: async () => await res.json(),
+    401: () => Promise.reject(new Error('로그인이 필요합니다')),
+    404: () => Promise.reject(new Error('요청 경로가 잘못되었습니다')),
+    500: () => Promise.reject(new Error('서버 오류가 발생했습니다')),
+  };
+
+  const defaultHandler = () =>
+    Promise.reject(
+      new Error(`예상치 못한 오류가 발생했습니다 (status: ${res.status})`),
+    );
+
+  return (statusCodeHandler[res.status] ?? defaultHandler)();
+}

--- a/frontend/src/features/milestone/hooks/useMilestones.ts
+++ b/frontend/src/features/milestone/hooks/useMilestones.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import getMilestones from '../api/getMilestones';
+import { type GetMilestonesResponse } from '../types';
+
+export default function useMilestones() {
+  const { data, isLoading, isError, refetch } = useQuery<GetMilestonesResponse>(
+    {
+      queryKey: ['milestones'],
+      queryFn: getMilestones,
+      staleTime: 1000 * 60 * 1,
+    },
+  );
+
+  return {
+    milestones: data?.milestones ?? [],
+    isLoading,
+    isError,
+    refetch,
+  };
+}

--- a/frontend/src/features/milestone/types.ts
+++ b/frontend/src/features/milestone/types.ts
@@ -4,6 +4,7 @@ export interface MilestoneShort {
 }
 
 export interface MilestoneDetail extends MilestoneShort {
+  progressRate: number;
   totalIssueCount: number;
   closedIssueCount: number;
 }

--- a/frontend/src/features/newIssue/components/NewIssueFormSection.tsx
+++ b/frontend/src/features/newIssue/components/NewIssueFormSection.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import Profile from '@/shared/components/Profile';
 import IssueForm from './NewIssueForm';
+import IssueSidebar from '@/features/issue/components/IssueSidebar';
 
 interface NewIssueFormSectionProps {
   title: string;
@@ -10,7 +11,7 @@ interface NewIssueFormSectionProps {
   onContentChange: (value: string) => void;
 
   milestoneId: number | null;
-  onMilestoneChange: (id: number | null) => void;
+  onMilestoneChange: (id: number) => void;
 
   selectedLabelIds: number[];
   onToggleLabel: (id: number) => void;
@@ -24,6 +25,12 @@ export default function NewIssueFormSection({
   onTitleChange,
   content,
   onContentChange,
+  milestoneId,
+  onMilestoneChange,
+  selectedLabelIds,
+  onToggleLabel,
+  selectedAssigneeIds,
+  onToggleAssignee,
 }: NewIssueFormSectionProps) {
   return (
     <MainWrapper>
@@ -34,7 +41,14 @@ export default function NewIssueFormSection({
         onTitleChange={onTitleChange}
         onContentChange={onContentChange}
       />
-      {/* sidebar */}
+      <IssueSidebar
+        selectedAssigneeIds={selectedAssigneeIds}
+        onToggleAssignee={onToggleAssignee}
+        selectedLabelIds={selectedLabelIds}
+        onToggleLabel={onToggleLabel}
+        selectedMilestoneId={milestoneId}
+        onSelectMilestone={onMilestoneChange}
+      />
     </MainWrapper>
   );
 }

--- a/frontend/src/pages/IssueDetailPage.tsx
+++ b/frontend/src/pages/IssueDetailPage.tsx
@@ -56,11 +56,8 @@ export default function IssueDetailPage() {
           author={issueDetail.author}
         />
         <SideSection>
-          <IssueSidebar
-            assignees={issueDetail.assignees}
-            labels={issueDetail.labels}
-            milestone={issueDetail.milestone}
-          />
+          {/* TODO 이슈 상세 편집을 위한 상태 설계 후 사이드바 추가 */}
+          {/* <IssueSidebar /> */}
           <TabItem icon={<TrashIcon />} label="이슈 삭제" />
         </SideSection>
       </MainArea>

--- a/frontend/src/pages/NewIssuePage.tsx
+++ b/frontend/src/pages/NewIssuePage.tsx
@@ -25,8 +25,30 @@ export default function NewIssuePage() {
   function handleCreateIssue() {
     const payload = buildIssuePayload(issueForm);
     console.log('[POST] /api/v1/issues payload:', payload);
-
     postNewIssue(payload);
+  }
+
+  function handleTitleChange(val: string) {
+    updateIssueForm({ type: 'SET_TITLE', payload: val });
+  }
+
+  function handleContentChange(val: string) {
+    updateIssueForm({ type: 'SET_CONTENT', payload: val });
+  }
+
+  function handleMilestoneChange(id: number) {
+    updateIssueForm({
+      type: 'SET_MILESTONE',
+      payload: issueForm.milestone === id ? null : id,
+    });
+  }
+
+  function handleToggleLabel(id: number) {
+    updateIssueForm({ type: 'TOGGLE_LABEL', payload: id });
+  }
+
+  function handleToggleAssignee(id: number) {
+    updateIssueForm({ type: 'TOGGLE_ASSIGNEE', payload: id });
   }
 
   return (
@@ -35,25 +57,15 @@ export default function NewIssuePage() {
       <Divider />
       <NewIssueFormSection
         title={issueForm.title}
-        onTitleChange={val =>
-          updateIssueForm({ type: 'SET_TITLE', payload: val })
-        }
+        onTitleChange={handleTitleChange}
         content={issueForm.content}
-        onContentChange={val =>
-          updateIssueForm({ type: 'SET_CONTENT', payload: val })
-        }
+        onContentChange={handleContentChange}
         milestoneId={issueForm.milestone}
-        onMilestoneChange={id =>
-          updateIssueForm({ type: 'SET_MILESTONE', payload: id })
-        }
+        onMilestoneChange={handleMilestoneChange}
         selectedLabelIds={issueForm.labels}
-        onToggleLabel={id =>
-          updateIssueForm({ type: 'TOGGLE_LABEL', payload: id })
-        }
+        onToggleLabel={handleToggleLabel}
         selectedAssigneeIds={issueForm.assignees}
-        onToggleAssignee={id =>
-          updateIssueForm({ type: 'TOGGLE_ASSIGNEE', payload: id })
-        }
+        onToggleAssignee={handleToggleAssignee}
       />
       <Divider />
       <NewIssueActionButtons


### PR DESCRIPTION
## 📌 PR 제목  
[Refactor] 마일스톤 타입 정비 및 사이드바 통합 적용  

## ✅ 작업 요약  
- 마일스톤 타입에 `progressRate`를 추가하여 상세 정보 표시를 위한 확장 준비  
- 마일스톤 전체 정보를 가져오는 API와 커스텀 훅 추가 (`useMilestones`)  
- 이슈 생성 페이지에 담당자, 레이블, 마일스톤 섹션을 포함한 사이드바 UI 적용  
- `onMilestoneChange` prop 타입을 number로 명확히 지정하여 일관성 확보
- 타입을 도메인별로 분리하여(`label`, `user`, `milestone`, `issue`) 중복 제거 및 유지보수성 향상  
- 이슈 상세 페이지 리디자인을 위해 사이드바 임시 주석 처리  

## ✅ 테스트 확인  
- [x] 이슈 생성 페이지에서 사이드바 UI가 정상 렌더링되는지 확인  
- [x] 각 섹션(담당자, 레이블, 마일스톤)에서 선택 및 반영 동작 확인  
- [x] 타입 에러 없이 전반적인 타입 정합성 유지됨 확인  

## 🧠 회고/고민  
- 사이드바의 섹션을 공통 컴포넌트로 추상화했었으나, 각 섹션의 로직 및 UI 특성이 달라 별도 구현이 유지보수에 더 유리하다고 판단하여 별도의 섹션 컴포넌트를 각각 구현함

cloess #59
