### PR TITLE
[Feature] S3 업로드 및 마크다운 삽입 기능 구현

### DIFF
--- a/frontend/src/features/newIssue/apis/uploadToS3.ts
+++ b/frontend/src/features/newIssue/apis/uploadToS3.ts
@@ -1,0 +1,20 @@
+import { API } from '@/shared/constants/api';
+
+export default async function uploadToS3(file: File): Promise<string> {
+  const res = await fetch(`${API.S3_PRESIGNED_URL}?filename=${file.name}`);
+  if (!res.ok) throw new Error('Failed to get presigned URL');
+
+  const presignedUrl = await res.text();
+
+  const uploadRes = await fetch(presignedUrl, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': file.type,
+    },
+    body: file,
+  });
+
+  if (!uploadRes.ok) throw new Error('Failed to upload file to S3');
+
+  return presignedUrl.split('?')[0];
+}

--- a/frontend/src/features/newIssue/components/CommentInputSection.tsx
+++ b/frontend/src/features/newIssue/components/CommentInputSection.tsx
@@ -5,7 +5,7 @@ import CommentMetaBar from './CommentMetaBar';
 
 interface CommentInputSectionProps {
   value: string;
-  onChange: (value: string) => void;
+  onChange: (value: string | ((prev: string) => string)) => void;
 }
 
 export default function CommentInputSection({

--- a/frontend/src/features/newIssue/components/NewIssueForm.tsx
+++ b/frontend/src/features/newIssue/components/NewIssueForm.tsx
@@ -7,7 +7,7 @@ interface NewIssueFormProps {
   onTitleChange: (value: string) => void;
 
   content: string;
-  onContentChange: (value: string) => void;
+  onContentChange: (value: string | ((prev: string) => string)) => void;
 }
 
 export default function NewIssueForm({

--- a/frontend/src/features/newIssue/components/NewIssueFormSection.tsx
+++ b/frontend/src/features/newIssue/components/NewIssueFormSection.tsx
@@ -8,7 +8,7 @@ interface NewIssueFormSectionProps {
   onTitleChange: (value: string) => void;
 
   content: string;
-  onContentChange: (value: string) => void;
+  onContentChange: (value: string | ((prev: string) => string)) => void;
 
   milestoneId: number | null;
   onMilestoneChange: (id: number) => void;

--- a/frontend/src/features/newIssue/reducers/newIssueFormReducer.ts
+++ b/frontend/src/features/newIssue/reducers/newIssueFormReducer.ts
@@ -3,7 +3,7 @@ import { type NewIssueState } from '../types';
 
 export type Action =
   | { type: 'SET_TITLE'; payload: string }
-  | { type: 'SET_CONTENT'; payload: string }
+  | { type: 'SET_CONTENT'; payload: string | ((prev: string) => string) }
   | { type: 'SET_MILESTONE'; payload: number | null }
   | { type: 'TOGGLE_LABEL'; payload: number }
   | { type: 'TOGGLE_ASSIGNEE'; payload: number }
@@ -16,8 +16,13 @@ export function newIssueFormReducer(
   switch (action.type) {
     case 'SET_TITLE':
       return { ...state, title: action.payload };
-    case 'SET_CONTENT':
-      return { ...state, content: action.payload };
+    case 'SET_CONTENT': {
+      const nextContent =
+        typeof action.payload === 'function'
+          ? action.payload(state.content)
+          : action.payload;
+      return { ...state, content: nextContent };
+    }
     case 'SET_MILESTONE':
       return { ...state, milestone: action.payload };
     case 'TOGGLE_LABEL':

--- a/frontend/src/pages/NewIssuePage.tsx
+++ b/frontend/src/pages/NewIssuePage.tsx
@@ -32,10 +32,9 @@ export default function NewIssuePage() {
     updateIssueForm({ type: 'SET_TITLE', payload: val });
   }
 
-  function handleContentChange(val: string) {
+  function handleContentChange(val: string | ((prev: string) => string)) {
     updateIssueForm({ type: 'SET_CONTENT', payload: val });
   }
-
   function handleMilestoneChange(id: number) {
     updateIssueForm({
       type: 'SET_MILESTONE',

--- a/frontend/src/shared/constants/api.ts
+++ b/frontend/src/shared/constants/api.ts
@@ -10,4 +10,5 @@ export const API = {
   MILESTONES: `${API_BASE_URL}/milestones`,
   MILESTONES_SHORT: `${API_BASE_URL}/milestones/short`,
   USERS: `${API_BASE_URL}/users`,
+  S3_PRESIGNED_URL: `${API_BASE_URL}/s3/presigned-url`,
 };


### PR DESCRIPTION
## 📌 PR 제목

[Feature] S3 업로드 및 마크다운 삽입 기능 구현

## ✅ 작업 요약

- [x] 이슈 내용 작성 시 이미지 파일을 S3에 업로드하고, 해당 URL을 마크다운 형식으로 본문에 삽입하는 기능 구현
- [x] 업로드 후 콘텐츠 dispatch에 함수형 payload를 지원하도록 리팩토링
- [x] 타입 정의도 함수형 payload를 수용할 수 있도록 수정

## ✅ 테스트 확인

- [x] 이미지 업로드 시 자동으로 `![image](url)` 마크다운 삽입 확인
- [x] 파일 업로드 후 텍스트에 정상적으로 반영됨을 확인
- [x] 동일한 파일을 재업로드할 수 있도록 input 초기화 기능 정상 작동 확인
- [x] 모든 관련 로직 정상 동작 확인 (수동 테스트)

## 🧠 회고/고민

### 1. 파일 업로드 병렬 처리 여부

#### 고민의 배경
- 복수 파일을 업로드할 경우 병렬로 처리하면 속도는 빨라지지만, 에러 핸들링이나 순서 보장이 어렵고, 마크다운 삽입 순서와의 정합성 문제가 발생할 수 있음

#### 결정 및 처리
- 현재는 단일 파일 기준으로 구현
- 향후 다중 파일 업로드 지원 시, 순차 처리 방식과 병렬 처리 방식 중 마크다운 삽입 순서를 보장할 수 있는 구조로 리팩토링 예정

---

### 2. S3 업로드 함수의 단일 책임 분리

#### 고민의 배경
- 업로드 함수에서 마크다운 문자열까지 반환할지, 순수하게 URL만 반환할지 고민
- 마크다운 포맷은 UI 로직이므로, 도메인 로직과 분리하는 것이 유지보수성과 테스트 측면에서 적합하다고 판단

#### 결정 및 처리
- `uploadToS3` 함수는 순수하게 URL만 반환하고, 마크다운 포맷은 상위 로직에서 구성하도록 분리

---

### 3. input file의 동일 파일 재업로드 인식 문제

#### 발생한 문제
- 동일한 파일을 두 번 선택해도 `onChange` 이벤트가 발생하지 않아 아무 일도 일어나지 않는 현상 발생
- 원인은 input[type="file"]은 같은 파일 선택 시 value가 변하지 않으면 change 이벤트를 발생시키지 않기 때문

#### 해결 방법
- 공식 문서 및 여러 참고자료를 통해 문제 원인을 확인
- 업로드 후 input 요소의 `.value = ''` 초기화 처리를 명시적으로 추가하여 동일 파일도 재업로드 가능하도록 수정

## 🔗 참고 자료

- [MDN - `<input type="file">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#value)
- [S3 Presigned URL 공식문서](https://docs.aws.amazon.com/AmazonS3/latest/userguide/PresignedUrlUploadObject.html)
closes #124 
