### PR TITLE
[Feature] 댓글 수정 API 구현

### DIFF
--- a/backend/src/main/java/elbin_bank/issue_tracker/comment/application/command/CommentCommandService.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/comment/application/command/CommentCommandService.java
@@ -1,23 +1,45 @@
 package elbin_bank.issue_tracker.comment.application.command;
 
+import elbin_bank.issue_tracker.comment.application.query.CommentsQueryRepository;
 import elbin_bank.issue_tracker.comment.domain.Comment;
 import elbin_bank.issue_tracker.comment.domain.CommentCommandRepository;
+import elbin_bank.issue_tracker.comment.exception.CommentNotFoundException;
+import elbin_bank.issue_tracker.comment.infrastructure.query.projection.CommentProjection;
 import elbin_bank.issue_tracker.comment.presentation.command.dto.request.CommentCreateRequestDto;
+import elbin_bank.issue_tracker.comment.presentation.command.dto.request.CommentUpdateRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
 public class CommentCommandService {
 
     private final CommentCommandRepository commentCommandRepository;
+    private final CommentsQueryRepository commentsQueryRepository;
 
+    @Transactional
     public void createComment(CommentCreateRequestDto requestDto, Long id) {
         long mockUserId = 1L; // todo: 로그인 구현 후 변경 예정
 
         Comment comment = Comment.of(id, mockUserId, requestDto.content());
 
         commentCommandRepository.save(comment);
+    }
+
+    @Transactional
+    public void updateComment(CommentUpdateRequestDto commentUpdateRequestDto, Long id, Long commentId) {
+        List<CommentProjection> comments = commentsQueryRepository.findByIssueId(id);
+
+        CommentProjection comment = comments.stream()
+                .filter(commentProjection -> Objects.equals(commentProjection.id(), commentId))
+                .findFirst()
+                .orElseThrow(() -> new CommentNotFoundException(commentId));
+
+        commentCommandRepository.updateComment(comment, commentUpdateRequestDto);
     }
 
 }

--- a/backend/src/main/java/elbin_bank/issue_tracker/comment/domain/CommentCommandRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/comment/domain/CommentCommandRepository.java
@@ -1,7 +1,12 @@
 package elbin_bank.issue_tracker.comment.domain;
 
+import elbin_bank.issue_tracker.comment.infrastructure.query.projection.CommentProjection;
+import elbin_bank.issue_tracker.comment.presentation.command.dto.request.CommentUpdateRequestDto;
+
 public interface CommentCommandRepository {
 
     void save(Comment comment);
+
+    void updateComment(CommentProjection comment, CommentUpdateRequestDto commentUpdateRequestDto);
 
 }

--- a/backend/src/main/java/elbin_bank/issue_tracker/comment/exception/CommentNotFoundException.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/comment/exception/CommentNotFoundException.java
@@ -1,0 +1,7 @@
+package elbin_bank.issue_tracker.comment.exception;
+
+public class CommentNotFoundException extends RuntimeException {
+    public CommentNotFoundException(long id) {
+        super("Could not find comment with id " + id);
+    }
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/comment/infrastructure/command/JdbcCommentCommandRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/comment/infrastructure/command/JdbcCommentCommandRepository.java
@@ -2,6 +2,8 @@ package elbin_bank.issue_tracker.comment.infrastructure.command;
 
 import elbin_bank.issue_tracker.comment.domain.Comment;
 import elbin_bank.issue_tracker.comment.domain.CommentCommandRepository;
+import elbin_bank.issue_tracker.comment.infrastructure.query.projection.CommentProjection;
+import elbin_bank.issue_tracker.comment.presentation.command.dto.request.CommentUpdateRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -26,6 +28,22 @@ public class JdbcCommentCommandRepository implements CommentCommandRepository {
                 .addValue("issueId", comment.getIssueId())
                 .addValue("userId", comment.getUserId())
                 .addValue("contents", comment.getContents());
+
+        jdbc.update(sql, params);
+    }
+
+    @Override
+    public void updateComment(CommentProjection comment, CommentUpdateRequestDto commentUpdateRequestDto) {
+        String sql = """
+                    UPDATE comment
+                       SET contents = :contents,
+                           updated_at = NOW()
+                     WHERE id = :id
+                """;
+
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("contents", commentUpdateRequestDto.content())
+                .addValue("id", comment.id());
 
         jdbc.update(sql, params);
     }

--- a/backend/src/main/java/elbin_bank/issue_tracker/comment/infrastructure/query/JdbcCommentsQueryRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/comment/infrastructure/query/JdbcCommentsQueryRepository.java
@@ -20,8 +20,12 @@ public class JdbcCommentsQueryRepository implements CommentsQueryRepository {
 
     @Override
     public List<CommentProjection> findByIssueId(Long issueId) {
-        String sql = "SELECT id, user_id, contents, created_at, updated_at FROM comment WHERE issue_id = :issueId";
-
+        String sql = """
+                    SELECT id, user_id, contents, created_at, updated_at
+                      FROM comment
+                     WHERE issue_id = :issueId
+                       AND deleted_at IS NULL
+                """;
         MapSqlParameterSource params = new MapSqlParameterSource()
                 .addValue("issueId", issueId);
 

--- a/backend/src/main/java/elbin_bank/issue_tracker/comment/presentation/command/CommentCommandController.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/comment/presentation/command/CommentCommandController.java
@@ -2,6 +2,7 @@ package elbin_bank.issue_tracker.comment.presentation.command;
 
 import elbin_bank.issue_tracker.comment.application.command.CommentCommandService;
 import elbin_bank.issue_tracker.comment.presentation.command.dto.request.CommentCreateRequestDto;
+import elbin_bank.issue_tracker.comment.presentation.command.dto.request.CommentUpdateRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +20,13 @@ public class CommentCommandController {
         commentCommandService.createComment(commentCreateRequestDto, id);
 
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PutMapping("/{id}/comments/{commentId}")
+    public ResponseEntity<Void> updateComment(@RequestBody CommentUpdateRequestDto commentUpdateRequestDto, @PathVariable Long id, @PathVariable Long commentId) {
+        commentCommandService.updateComment(commentUpdateRequestDto, id, commentId);
+
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
 }

--- a/backend/src/main/java/elbin_bank/issue_tracker/comment/presentation/command/dto/request/CommentUpdateRequestDto.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/comment/presentation/command/dto/request/CommentUpdateRequestDto.java
@@ -1,0 +1,4 @@
+package elbin_bank.issue_tracker.comment.presentation.command.dto.request;
+
+public record CommentUpdateRequestDto(String content) {
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/common/advice/GlobalExceptionHandler.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/common/advice/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package elbin_bank.issue_tracker.common.advice;
 
+import elbin_bank.issue_tracker.comment.exception.CommentNotFoundException;
 import elbin_bank.issue_tracker.issue.exception.IssueDetailNotFoundException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.HttpStatus;
@@ -11,7 +12,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     // 조회 결과가 없을 때 404만
-    @ExceptionHandler({IssueDetailNotFoundException.class, EmptyResultDataAccessException.class})
+    @ExceptionHandler({IssueDetailNotFoundException.class, CommentNotFoundException.class, EmptyResultDataAccessException.class})
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public void handleNotFound() {
     }


### PR DESCRIPTION
## **✅ 작업 요약**

- PUT /api/v1/issues/{id}/comments/{commentId} 엔드포인트에서 댓글 수정 API 구현
- **CommentCommandService**
    - 요청받은 CommentUpdateRequest 기반으로 Comment 객체 content 수정
    - JdbcCommentCommandRepository.findByIssueId(...) 호출로 해당 이슈의 comment 추출
    - 반환된 comment에
        - commentCommandRepository.updateComment(...) 로 comment의 content 수정
        
- **JdbcCommentCommandRepository**
    - Comment의 content를 수정하기 위한 updateComment() 메서드 추가

## **✅ 테스트 확인**

- PUT /api/v1/issues/{id}/comments/{commentId} 요청 시
    해당 issue의 해당 comment의 content 수정

## **🧠 회고/고민**

- error 처리를 어떤 방식으로 할지에 대해 고민했던 거 같습니다. 기존의 try-catch 방식으로 하려했지만 이 방식은 확장성에 문제가 있다고 판단하여 ControllerAdvice를 활용해 에러 처리를 해주었습니다.