### PR TITLE
[Hotfix] S3 presigned URL 경로 수정 및 마일스톤 204 응답 처리 개선

### DIFF
--- a/frontend/src/features/issue/api/getIssueMilestone.ts
+++ b/frontend/src/features/issue/api/getIssueMilestone.ts
@@ -14,11 +14,12 @@ export async function getIssueMilestone(
     () => Promise<MilestoneDetail | null>
   > = {
     200: async () => await res.json(),
+    204: () => Promise.resolve(null),
     401: () => {
       window.location.href = '/login';
       return Promise.reject(new Error('로그인이 필요합니다'));
     },
-    404: () => Promise.resolve(null), // 없을 수 있으므로 null 처리
+    404: () => Promise.reject(new Error('요청 경로가 잘못되었습니다')),
     500: () => Promise.reject(new Error('서버 오류가 발생했습니다')),
   };
 

--- a/frontend/src/pages/IssueDetailPage.tsx
+++ b/frontend/src/pages/IssueDetailPage.tsx
@@ -46,10 +46,6 @@ export default function IssueDetailPage() {
     isError: isCommentError,
   } = useIssueComments(issueId);
 
-  const selectedAssigneeIds = issueAssignees.map(assignee => assignee.id);
-  const selectedLabelIds = issueLabels.map(label => label.id);
-  const selectedMilestoneId = issueMilestone?.id ?? null;
-
   // TODO 로딩,에러 상태에 따라 분기처리 내부적으로 처리
   if (
     isIssueDetailLoading ||
@@ -71,14 +67,11 @@ export default function IssueDetailPage() {
     return <div>에러 발생</div>;
   }
 
-  if (
-    !issueDetail ||
-    !commentList ||
-    !issueAssignees ||
-    !issueLabels ||
-    !issueMilestone
-  )
-    return;
+  if (!issueDetail || !commentList || !issueAssignees || !issueLabels) return;
+
+  const selectedAssigneeIds = issueAssignees.map(assignee => assignee.id);
+  const selectedLabelIds = issueLabels.map(label => label.id);
+  const selectedMilestoneId = issueMilestone?.id ?? null;
 
   return (
     <VerticalStack>

--- a/frontend/src/shared/constants/api.ts
+++ b/frontend/src/shared/constants/api.ts
@@ -13,5 +13,5 @@ export const API = {
   MILESTONES: `${API_BASE_URL}/milestones`,
   MILESTONES_SHORT: `${API_BASE_URL}/milestones/short`,
   USERS: `${API_BASE_URL}/users`,
-  S3_PRESIGNED_URL: `${API_BASE_URL}/s3/presigned-url`,
+  S3_PRESIGNED_URL: '/api/s3/presigned-url',
 };


### PR DESCRIPTION
## 🎯 목적

- S3 presigned URL 요청 경로 변경 반영
- 마일스톤이 없는 경우 서버에서 204 No Content를 반환하도록 변경됨에 따라, 프론트엔드에서도 null 처리 로직 개선
- milestone이 null일 때 렌더링 조건을 보완하여 빈 섹션이 나타나지 않도록 수정


## 🧩 작업 내용

- [x] `S3_PRESIGNED_URL` 경로를 `/api/s3/presigned-url`로 수정
- [x] milestone 조회 시 204 응답을 null로 처리하도록 fetch 함수 로직 변경
- [x] milestone이 null인 경우 관련 섹션 렌더링하지 않도록 분기 처리


## ✅ 완료 조건

- [x] milestone이 없는 이슈에서도 오류 없이 정상 렌더링됨
- [x] presigned URL 요청 시 정상적으로 S3 업로드 URL을 획득할 수 있음\

closes #149 