### PR TITLE
[refactor] presigned URL 요청 시 Content-Type 쿼리 파라미터 추가 및 백엔드와 동기화

### DIFF
--- a/frontend/src/features/newIssue/apis/uploadToS3.ts
+++ b/frontend/src/features/newIssue/apis/uploadToS3.ts
@@ -1,7 +1,10 @@
 import { API } from '@/shared/constants/api';
 
 export default async function uploadToS3(file: File): Promise<string> {
-  const res = await fetch(`${API.S3_PRESIGNED_URL}?filename=${file.name}`);
+  const res = await fetch(
+    `${API.S3_PRESIGNED_URL}?filename=${file.name}&Content-Type=${encodeURIComponent(file.type)}`,
+  );
+
   if (!res.ok) throw new Error('Failed to get presigned URL');
 
   const presignedUrl = await res.text();


### PR DESCRIPTION
## 📌 PR 제목

[refactor] presigned URL 요청 시 Content-Type 쿼리 파라미터 추가 및 백엔드와 동기화

## ✅ 작업 요약

- presigned URL 요청 시 Content-Type 쿼리 파라미터 추가
- MIME 타입 문자열에 encodeURIComponent 적용
- 관련 fetch 요청 로직 (uploadToS3.ts) 수정

## 🧠 회고/고민

s3에 올라가지 않는 문제를 디버깅을 해보면서 s3 사용시 버킷 설정에 따라 CORS 문제가 발생함을 깨달았고, presigned url의 권한에 대해서 공부하는 게기가 되었습니다.

## 🔗 참고 자료

[참고 블로그](https://songsong.dev/entry/S3%EC%97%90-%ED%8C%8C%EC%9D%BC%EC%9D%84-%EC%97%85%EB%A1%9C%EB%93%9C%ED%95%98%EB%8A%94-%EC%84%B8-%EA%B0%80%EC%A7%80-%EB%B0%A9%EB%B2%95)

closes #151