### PR TITLE
[Feat] 이슈 상태 토글 기능 구현 및 캐시 최적화

### DIFF
--- a/frontend/src/features/issue/api/patchIssueState.ts
+++ b/frontend/src/features/issue/api/patchIssueState.ts
@@ -1,0 +1,37 @@
+import { API } from '@/shared/constants/api';
+
+interface PatchIssueStateParams {
+  issueId: number;
+  targetClosed: boolean;
+}
+
+export default async function patchIssueState({
+  issueId,
+  targetClosed,
+}: PatchIssueStateParams): Promise<void> {
+  const response = await fetch(API.ISSUE_STATE(issueId), {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    // credentials: 'include',
+    body: JSON.stringify({ targetClosed }),
+  });
+
+  const statusCodeHandler: Record<number, () => Promise<void>> = {
+    204: () => Promise.resolve(),
+    401: () => {
+      window.location.href = '/login';
+      return Promise.reject(new Error('로그인이 필요합니다'));
+    },
+    404: () => Promise.reject(new Error('요청 경로가 잘못되었습니다')),
+    500: () => Promise.reject(new Error('서버 오류가 발생했습니다')),
+  };
+
+  const defaultHandler = () =>
+    Promise.reject(
+      new Error(`예상치 못한 오류가 발생했습니다 (status: ${response.status})`),
+    );
+
+  return (statusCodeHandler[response.status] ?? defaultHandler)();
+}

--- a/frontend/src/features/issue/components/detail/IssueHeader.tsx
+++ b/frontend/src/features/issue/components/detail/IssueHeader.tsx
@@ -16,6 +16,7 @@ interface IssueHeaderProps {
   };
   createdAt: string;
   commentCount: number;
+  onToggleIssueState: () => void;
 }
 
 //TODO 편집 기능, 이슈 열림 토글 기능 추가시 prop도 추가
@@ -26,6 +27,7 @@ export default function IssueHeader({
   author,
   createdAt,
   commentCount,
+  onToggleIssueState,
 }: IssueHeaderProps) {
   return (
     <HeaderWrapper>
@@ -34,7 +36,7 @@ export default function IssueHeader({
           {title} <IssueNumber>#{issueNumber}</IssueNumber>
         </Title>
         <IssueMetaWrapper>
-          <IsClosedButton>
+          <IsClosedButton isClosed={isClosed}>
             <AlertCircleIcon />
             <StateBadge>{isClosed ? '닫힌 이슈' : '열린 이슈'}</StateBadge>
           </IsClosedButton>
@@ -59,9 +61,7 @@ export default function IssueHeader({
           variant="outline"
           size="small"
           icon={<ClosedIcon />}
-          onClick={() => {
-            /* 이슈 열기/닫기 토글 로직 */
-          }}
+          onClick={onToggleIssueState}
         >
           {isClosed ? '이슈 열기' : '이슈 닫기'}
         </Button>
@@ -119,12 +119,14 @@ const CommentCount = styled.span`
   ${({ theme }) => theme.typography.displayMedium16};
 `;
 
-const IsClosedButton = styled.button`
+const IsClosedButton = styled.button<{ isClosed: boolean }>`
   display: flex;
   justify-content: center;
   align-items: center;
   padding: 8px 16px;
-  background-color: ${({ theme }) => theme.palette.blue};
+  background-color: ${({ theme, isClosed }) =>
+    isClosed ? theme.palette.navy : theme.palette.blue};
+
   border-radius: ${({ theme }) => theme.radius.large};
   color: ${({ theme }) => theme.brand.text.default};
 

--- a/frontend/src/features/issue/hooks/usePatchIssueState.ts
+++ b/frontend/src/features/issue/hooks/usePatchIssueState.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import patchIssueState from '@/features/issue/api/patchIssueState';
+import { type IssueDetailResponse } from '../types/issue';
+
+export default function usePatchIssueState(issueId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: patchIssueState,
+    onSuccess: () => {
+      queryClient.setQueryData(
+        ['issueDetail', issueId],
+        (prev: IssueDetailResponse) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            isClosed: !prev.isClosed,
+          };
+        },
+      );
+    },
+  });
+}

--- a/frontend/src/pages/IssueDetailPage.tsx
+++ b/frontend/src/pages/IssueDetailPage.tsx
@@ -6,6 +6,7 @@ import useIssueLabels from '@/features/issue/hooks/useIssueLabels';
 import useIssueMilestone from '@/features/issue/hooks/useIssueMilestone';
 import useIssueDetail from '@/features/issue/hooks/useIssueDetail';
 import useIssueComments from '@/features/issue/hooks/useIssueComments';
+import usePatchIssueState from '@/features/issue/hooks/usePatchIssueState';
 import Divider from '@/shared/components/Divider';
 import IssueHeader from '@/features/issue/components/detail/IssueHeader';
 import IssueMainSection from '@/features/issue/components/detail/IssueMainSection';
@@ -15,6 +16,8 @@ import VerticalStack from '@/layouts/VerticalStack';
 export default function IssueDetailPage() {
   const { id } = useParams();
   const issueId = Number(id);
+  const { mutate: toggleIssueState, isPending: isToggleLoading } =
+    usePatchIssueState(issueId);
 
   const {
     issueLabels,
@@ -45,6 +48,11 @@ export default function IssueDetailPage() {
     isLoading: isCommentLoading,
     isError: isCommentError,
   } = useIssueComments(issueId);
+
+  const handleIssueStateToggle = () => {
+    if (!issueDetail || isToggleLoading) return;
+    toggleIssueState({ issueId, targetClosed: !issueDetail.isClosed });
+  };
 
   // TODO 로딩,에러 상태에 따라 분기처리 내부적으로 처리
   if (
@@ -79,6 +87,7 @@ export default function IssueDetailPage() {
         {...issueDetail}
         issueNumber={issueDetail.id}
         commentCount={commentList.length}
+        onToggleIssueState={handleIssueStateToggle}
       />
       <Divider />
       <MainArea>

--- a/frontend/src/shared/constants/api.ts
+++ b/frontend/src/shared/constants/api.ts
@@ -9,6 +9,9 @@ export const API = {
   ISSUE_LABELS: (id: number) => `${API_BASE_URL}/issues/${id}/labels`,
   ISSUE_ASSIGNEES: (id: number) => `${API_BASE_URL}/issues/${id}/assignees`,
   ISSUE_MILESTONE: (id: number) => `${API_BASE_URL}/issues/${id}/milestone`,
+
+  ISSUE_STATE: (id: number) => `${API_BASE_URL}/issues/${id}/state`,
+
   LABELS: `${API_BASE_URL}/labels`,
   MILESTONES: `${API_BASE_URL}/milestones`,
   MILESTONES_SHORT: `${API_BASE_URL}/milestones/short`,


### PR DESCRIPTION
## 📌 PR 제목

[Feat] 이슈 상태 토글 기능 구현 및 캐시 최적화


## ✅ 작업 요약

이슈 상세 페이지에서 `이슈 닫기` / `다시 열기` 버튼을 클릭하면  
이슈 상태(`isClosed`)를 서버에 PATCH 요청으로 변경하고,  
그 결과를 다시 fetch하지 않고 React Query의 `setQueryData`를 활용해 캐시만 갱신하도록 구현했습니다.

또한 상태에 따라 버튼의 배경색을 파란색/보라색으로 동적으로 렌더링되도록 처리했습니다.  
서버 응답 코드(`204`, `401`, `404`, `500`)에 따라 분기 처리도 추가했습니다.


## ✅ 테스트 확인

- [x] 버튼 클릭 시 상태가 정상적으로 전환됨
- [x] 상태 전환 후 새로고침 없이 UI가 즉시 반영됨
- [x] 버튼 색상이 상태에 따라 올바르게 변경됨
- [x] 응답 코드에 따라 리디렉션 혹은 에러 메시지 처리가 정상 작동됨


## 🧠 회고/고민

처음에는 `invalidateQueries`를 사용해 서버에서 다시 상세 데이터를 받아오는 방식으로 구현하려 했지만,  
이슈 상태 변경의 경우 응답 데이터가 없고 변경된 값이 명확하게 예측 가능하기 때문에  
굳이 다시 요청하지 않고 캐시를 수동으로 갱신(`setQueryData`)하는 방식이 더 효율적이라고 판단했습니다.

결과적으로 네트워크 비용을 줄이면서도 UX는 동일하게 유지할 수 있었고,  
이후에도 비슷한 패턴의 상태 전환 로직에서 재사용 가능한 구조가 되도록 설계했습니다.


## 🔗 참고 자료

- [TanStack Query - setQueryData](https://tanstack.com/query/latest/docs/framework/react/guides/query-functions#updating-query-data)
- [MDN HTTP Status Codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status)

closes #153 