### PR TITLE
[Feature] 라벨 생성/수정 API 구현

### DIFF
--- a/backend/src/main/java/elbin_bank/issue_tracker/comment/domain/Comment.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/comment/domain/Comment.java
@@ -3,16 +3,12 @@ package elbin_bank.issue_tracker.comment.domain;
 import elbin_bank.issue_tracker.common.domain.BaseEntity;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Table;
 
 @Table("comment")
 @AllArgsConstructor
-@NoArgsConstructor
 @Getter
-@Setter
 public class Comment extends BaseEntity {
 
     @Id

--- a/backend/src/main/java/elbin_bank/issue_tracker/comment/presentation/command/CommentCommandController.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/comment/presentation/command/CommentCommandController.java
@@ -26,7 +26,7 @@ public class CommentCommandController {
     public ResponseEntity<Void> updateComment(@RequestBody CommentUpdateRequestDto commentUpdateRequestDto, @PathVariable Long id, @PathVariable Long commentId) {
         commentCommandService.updateComment(commentUpdateRequestDto, id, commentId);
 
-        return ResponseEntity.status(HttpStatus.OK).build();
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
 }

--- a/backend/src/main/java/elbin_bank/issue_tracker/common/advice/GlobalExceptionHandler.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/common/advice/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package elbin_bank.issue_tracker.common.advice;
 import elbin_bank.issue_tracker.comment.exception.CommentNotFoundException;
 import elbin_bank.issue_tracker.issue.exception.IssueDetailNotFoundException;
 import elbin_bank.issue_tracker.issue.exception.MilestoneForIssueNotFoundException;
+import elbin_bank.issue_tracker.label.exception.LabelNotFoundException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -18,7 +19,7 @@ public class GlobalExceptionHandler {
     }
 
     // 조회 결과가 없을 때 404만
-    @ExceptionHandler({IssueDetailNotFoundException.class, CommentNotFoundException.class, EmptyResultDataAccessException.class})
+    @ExceptionHandler({IssueDetailNotFoundException.class, CommentNotFoundException.class, LabelNotFoundException.class, EmptyResultDataAccessException.class})
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public void handleNotFound() {
     }

--- a/backend/src/main/java/elbin_bank/issue_tracker/issue/application/query/IssueQueryService.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/issue/application/query/IssueQueryService.java
@@ -7,7 +7,6 @@ import elbin_bank.issue_tracker.issue.application.query.mapper.IssueDtoMapper;
 import elbin_bank.issue_tracker.issue.application.query.repository.IssueQueryRepository;
 import elbin_bank.issue_tracker.issue.exception.IssueDetailNotFoundException;
 import elbin_bank.issue_tracker.issue.exception.MilestoneForIssueNotFoundException;
-import elbin_bank.issue_tracker.issue.infrastructure.query.projection.IssueCountProjection;
 import elbin_bank.issue_tracker.issue.infrastructure.query.projection.IssueDetailProjection;
 import elbin_bank.issue_tracker.issue.infrastructure.query.projection.IssueProjection;
 import elbin_bank.issue_tracker.issue.infrastructure.query.projection.UserInfoProjection;

--- a/backend/src/main/java/elbin_bank/issue_tracker/label/application/command/LabelCommandService.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/label/application/command/LabelCommandService.java
@@ -1,0 +1,38 @@
+package elbin_bank.issue_tracker.label.application.command;
+
+import elbin_bank.issue_tracker.comment.exception.CommentNotFoundException;
+import elbin_bank.issue_tracker.label.application.query.repository.LabelQueryRepository;
+import elbin_bank.issue_tracker.label.domain.Label;
+import elbin_bank.issue_tracker.label.domain.LabelCommandRepository;
+import elbin_bank.issue_tracker.label.exception.LabelNotFoundException;
+import elbin_bank.issue_tracker.label.infrastructure.query.projection.LabelProjection;
+import elbin_bank.issue_tracker.label.presentation.command.dto.request.LabelCreateRequestDto;
+import elbin_bank.issue_tracker.label.presentation.command.dto.request.LabelUpdateRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class LabelCommandService {
+
+    private final LabelCommandRepository labelCommandRepository;
+    private final LabelQueryRepository labelQueryRepository;
+
+    @Transactional
+    public void createLabel(LabelCreateRequestDto labelCreateRequestDto) {
+        Label label = Label.of(labelCreateRequestDto.name(), labelCreateRequestDto.description(), labelCreateRequestDto.color());
+
+        labelCommandRepository.save(label);
+    }
+
+    @Transactional
+    public void updateLabel(LabelUpdateRequestDto labelUpdateRequestDto, Long id) {
+        LabelProjection label = Optional.ofNullable(labelQueryRepository.findById(id))
+                .orElseThrow(() -> new LabelNotFoundException(id));
+
+        labelCommandRepository.update(label, labelUpdateRequestDto);
+    }
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/label/application/query/repository/LabelQueryRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/label/application/query/repository/LabelQueryRepository.java
@@ -7,6 +7,8 @@ import java.util.Map;
 
 public interface LabelQueryRepository {
 
+    LabelProjection findById(Long id);
+
     Map<Long, List<LabelProjection>> findByIssueIds(List<Long> issueIds);
 
     List<LabelProjection> findAll();

--- a/backend/src/main/java/elbin_bank/issue_tracker/label/domain/Label.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/label/domain/Label.java
@@ -3,21 +3,22 @@ package elbin_bank.issue_tracker.label.domain;
 import elbin_bank.issue_tracker.common.domain.BaseEntity;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
 @Table("label")
-@NoArgsConstructor
 @AllArgsConstructor
 @Getter
 public class Label extends BaseEntity {
 
     @Id
-    private long id;
+    private Long id;
     private String name;
     private String description;
     private String color;
+
+    public static Label of(String name, String description, String color) {
+        return new Label(null, name, description, color); // id는 DB에서 생성
+    }
 
 }

--- a/backend/src/main/java/elbin_bank/issue_tracker/label/domain/LabelCommandRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/label/domain/LabelCommandRepository.java
@@ -1,9 +1,15 @@
 package elbin_bank.issue_tracker.label.domain;
 
+import elbin_bank.issue_tracker.label.infrastructure.query.projection.LabelProjection;
+import elbin_bank.issue_tracker.label.presentation.command.dto.request.LabelUpdateRequestDto;
+
 import java.util.List;
 
 public interface LabelCommandRepository {
 
     void saveLabelsToIssue(Long issueId, List<Long> labelIds);
 
+    void save(Label label);
+
+    void update(LabelProjection label, LabelUpdateRequestDto labelUpdateRequestDto);
 }

--- a/backend/src/main/java/elbin_bank/issue_tracker/label/exception/LabelNotFoundException.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/label/exception/LabelNotFoundException.java
@@ -1,0 +1,7 @@
+package elbin_bank.issue_tracker.label.exception;
+
+public class LabelNotFoundException extends RuntimeException {
+    public LabelNotFoundException(Long id) {
+        super("Could not find label with id " + id);
+    }
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/label/infrastructure/command/JdbcLabelCommandRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/label/infrastructure/command/JdbcLabelCommandRepository.java
@@ -1,6 +1,9 @@
 package elbin_bank.issue_tracker.label.infrastructure.command;
 
+import elbin_bank.issue_tracker.label.domain.Label;
 import elbin_bank.issue_tracker.label.domain.LabelCommandRepository;
+import elbin_bank.issue_tracker.label.infrastructure.query.projection.LabelProjection;
+import elbin_bank.issue_tracker.label.presentation.command.dto.request.LabelUpdateRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -28,6 +31,40 @@ public class JdbcLabelCommandRepository implements LabelCommandRepository {
         var params = new MapSqlParameterSource()
                 .addValue("issueId", issueId)
                 .addValue("labelIds", labelIds);
+
+        jdbc.update(sql, params);
+    }
+
+    @Override
+    public void save(Label label) {
+        String sql = """
+                    INSERT INTO label
+                      (name, description, color)
+                    VALUES
+                      (:name, :description, :color)
+                """;
+
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("name", label.getName())
+                .addValue("description", label.getDescription())
+                .addValue("color", label.getColor());
+
+        jdbc.update(sql, params);
+    }
+
+    @Override
+    public void update(LabelProjection label, LabelUpdateRequestDto labelUpdateRequestDto) {
+        String sql = """
+                    UPDATE label
+                       SET name = :name, description = :description, color = :color, updated_at = NOW()
+                    WHERE id = :id
+                """;
+
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("name", labelUpdateRequestDto.name())
+                .addValue("description", labelUpdateRequestDto.description())
+                .addValue("color", labelUpdateRequestDto.color())
+                .addValue("id", label.id());
 
         jdbc.update(sql, params);
     }

--- a/backend/src/main/java/elbin_bank/issue_tracker/label/infrastructure/query/JdbcLabelQueryRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/label/infrastructure/query/JdbcLabelQueryRepository.java
@@ -3,6 +3,7 @@ package elbin_bank.issue_tracker.label.infrastructure.query;
 import elbin_bank.issue_tracker.label.application.query.repository.LabelQueryRepository;
 import elbin_bank.issue_tracker.label.infrastructure.query.projection.LabelProjection;
 import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -16,6 +17,27 @@ import java.util.stream.Collectors;
 public class JdbcLabelQueryRepository implements LabelQueryRepository {
 
     private final NamedParameterJdbcTemplate jdbc;
+
+    @Override
+    public LabelProjection findById(Long id) {
+        String sql = """
+                SELECT id,
+                       name,
+                       color,
+                       description
+                  FROM label
+                 WHERE id = :id
+                """;
+
+        var params = new MapSqlParameterSource("id", id);
+
+        return jdbc.queryForObject(sql, params, (rs, rowNum) -> new LabelProjection(
+                rs.getLong("id"),
+                rs.getString("name"),
+                rs.getString("color"),
+                rs.getString("description")
+        ));
+    }
 
     @Override
     public Map<Long, List<LabelProjection>> findByIssueIds(List<Long> issueIds) {

--- a/backend/src/main/java/elbin_bank/issue_tracker/label/presentation/command/LabelCommandController.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/label/presentation/command/LabelCommandController.java
@@ -1,0 +1,33 @@
+package elbin_bank.issue_tracker.label.presentation.command;
+
+import elbin_bank.issue_tracker.label.application.command.LabelCommandService;
+import elbin_bank.issue_tracker.label.presentation.command.dto.request.LabelCreateRequestDto;
+import elbin_bank.issue_tracker.label.presentation.command.dto.request.LabelUpdateRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/labels")
+public class LabelCommandController {
+
+    private final LabelCommandService labelCommandService;
+
+    @PostMapping("")
+    public ResponseEntity<Void> createLabel(@RequestBody LabelCreateRequestDto labelCreateRequestDto) {
+        labelCommandService.createLabel(labelCreateRequestDto);
+
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<Void> updateLabel(@RequestBody LabelUpdateRequestDto labelUpdateRequestDto, @PathVariable("id") Long id) {
+        labelCommandService.updateLabel(labelUpdateRequestDto, id);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/label/presentation/command/dto/request/LabelCreateRequestDto.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/label/presentation/command/dto/request/LabelCreateRequestDto.java
@@ -1,0 +1,4 @@
+package elbin_bank.issue_tracker.label.presentation.command.dto.request;
+
+public record LabelCreateRequestDto(String name, String description, String color) {
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/label/presentation/command/dto/request/LabelUpdateRequestDto.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/label/presentation/command/dto/request/LabelUpdateRequestDto.java
@@ -1,0 +1,4 @@
+package elbin_bank.issue_tracker.label.presentation.command.dto.request;
+
+public record LabelUpdateRequestDto(String name, String description, String color) {
+}


### PR DESCRIPTION
## **✅ 작업 요약**

- POST /api/v1/labels 엔드포인트에서 라벨 생성 API 구현
- PATCH /api/v1/labels/{id} 엔드포인트에서 라벨 수정 API 구현

## **✅ 테스트 확인**

- POST /api/v1/labels 요청 시
- PATCH /api/v1/labels/{id}
    - 요청 받은 정보로 라벨이 db에 잘 저장되고 수정되는지 확인 

## **🧠 회고/고민**

라벨 수정시 해당 id의 라벨을 조회해서 projection으로 변환 후 해당 projection을 넘겨주어 수정하는 식으로 로직을 작성했는데, projection으로 추출하지 않고 그냥 repository에서 쿼리 한번으로 처리했으면 어땠을까 하는 생각이 듭니다.