### PR TITLE
[Feature] 댓글 생성 기능 구현

### DIFF
--- a/frontend/src/features/issue/api/postComment.ts
+++ b/frontend/src/features/issue/api/postComment.ts
@@ -1,0 +1,32 @@
+import { API } from '@/shared/constants/api';
+
+export default async function postComment(
+  issueId: number,
+  content: string,
+): Promise<void> {
+  const response = await fetch(`${API.ISSUES}/${issueId}/comments`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      // 추후 로그인 기능이 들어가면  토큰 설정 필요
+    },
+    body: JSON.stringify({ content }),
+  });
+
+  const statusCodeHandler: Record<number, () => Promise<void>> = {
+    201: () => Promise.resolve(),
+    401: () => {
+      window.location.href = '/login';
+      return Promise.reject(new Error('로그인이 필요합니다'));
+    },
+    404: () => Promise.reject(new Error('요청 경로가 잘못되었습니다')),
+    500: () => Promise.reject(new Error('서버 오류가 발생했습니다')),
+  };
+
+  const defaultHandler = () =>
+    Promise.reject(
+      new Error(`예상치 못한 오류가 발생했습니다 (status: ${response.status})`),
+    );
+
+  return (statusCodeHandler[response.status] ?? defaultHandler)();
+}

--- a/frontend/src/features/issue/components/detail/CommentEditor.tsx
+++ b/frontend/src/features/issue/components/detail/CommentEditor.tsx
@@ -1,3 +1,50 @@
+import { useParams } from 'react-router-dom';
+import { useState } from 'react';
+import styled from '@emotion/styled';
+import useCreateComment from '../../hooks/useCreateComment';
+import CommentInputSection from '@/features/newIssue/components/CommentInputSection';
+import NewCommentActionButton from './NewCommentActionButton';
+
 export default function CommentEditor() {
-  return <div>CommentEditor</div>;
+  const { id } = useParams();
+  const [comment, setComment] = useState<string>('');
+
+  const issueId = Number(id);
+
+  const { mutate: createComment, isPending } = useCreateComment(issueId);
+
+  const handleCreateComment = () => {
+    if (!comment.trim()) return;
+    createComment(comment, {
+      onSuccess: () => {
+        setComment('');
+      },
+      onError: err => {
+        console.error(err.message);
+        // TODO 에러처리
+      },
+    });
+  };
+
+  return (
+    <NewCommentWrapper>
+      <CommentInputSection
+        value={comment}
+        onChange={value => setComment(value)}
+      />
+
+      <NewCommentActionButton
+        isSubmitDisabled={comment.trim() === '' || isPending}
+        onSubmit={handleCreateComment}
+      />
+    </NewCommentWrapper>
+  );
 }
+
+const NewCommentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 32px;
+  height: 248px;
+`;

--- a/frontend/src/features/issue/components/detail/CommentEditor.tsx
+++ b/frontend/src/features/issue/components/detail/CommentEditor.tsx
@@ -31,6 +31,7 @@ export default function CommentEditor() {
       <CommentInputSection
         value={comment}
         onChange={value => setComment(value)}
+        initialHeight={80}
       />
 
       <NewCommentActionButton
@@ -46,5 +47,4 @@ const NewCommentWrapper = styled.div`
   flex-direction: column;
   justify-content: flex-end;
   gap: 32px;
-  height: 248px;
 `;

--- a/frontend/src/features/issue/components/detail/NewCommentActionButton.tsx
+++ b/frontend/src/features/issue/components/detail/NewCommentActionButton.tsx
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+import Button from '@/shared/components/Button';
+import PlusIcon from '@/assets/icons/plus.svg?react';
+
+interface NewCommentActionButtonProps {
+  isSubmitDisabled: boolean;
+  onSubmit: () => void;
+}
+
+export default function NewCommentActionButton({
+  isSubmitDisabled,
+  onSubmit,
+}: NewCommentActionButtonProps) {
+  return (
+    <ButtonGroup>
+      <Button
+        size="small"
+        icon={<PlusIcon />}
+        disabled={isSubmitDisabled}
+        onClick={onSubmit}
+      >
+        코멘트 작성
+      </Button>
+    </ButtonGroup>
+  );
+}
+
+const ButtonGroup = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 24px;
+`;

--- a/frontend/src/features/issue/hooks/useCreateComment.ts
+++ b/frontend/src/features/issue/hooks/useCreateComment.ts
@@ -1,0 +1,13 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import postComment from '@/features/issue/api/postComment';
+
+export default function useCreateComment(issueId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (content: string) => postComment(issueId, content),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['issueComments', issueId] });
+    },
+  });
+}

--- a/frontend/src/features/newIssue/components/NewIssueForm.tsx
+++ b/frontend/src/features/newIssue/components/NewIssueForm.tsx
@@ -19,7 +19,11 @@ export default function NewIssueForm({
   return (
     <FormSection>
       <TitleInput value={title} onChange={onTitleChange} label="제목" />
-      <CommentInputSection value={content} onChange={onContentChange} />
+      <CommentInputSection
+        value={content}
+        onChange={onContentChange}
+        initialHeight={448}
+      />
     </FormSection>
   );
 }


### PR DESCRIPTION
## 📌 PR 제목

[Feature] 댓글 작성 UI 및 생성 기능 구현

## ✅ 작업 요약

- 이슈 상세 페이지에서 댓글을 작성하고 서버에 저장하는 기능 구현
- 댓글 입력 UI 구성 및 POST 요청을 위한 커스텀 훅 연동
- 댓글 작성 성공 시, 기존 목록 하단에 실시간으로 렌더링되도록 처리

## ✅ 작업 완료 내역

### ✨ 기능 추가
- 댓글 입력창, 글자 수 실시간 표시 UI 구현
- 이미지 업로드 → 마크다운 삽입 기능 (`![]()`) 추가
- 댓글 작성 시 POST API 요청 및 성공 후 상태 갱신 처리
- 이슈 생성 페이지에 적용한UI를 댓글 생성 UI에 적용

### 🏗️ 구조 및 설계
- 댓글 생성을 위한 `postComment` 함수 및 `useCreateComment` 커스텀 훅 생성
- 댓글 상태를 관리하는 전역/로컬 상태 로직 반영

## ✅ 테스트 확인

- [x] 빈 입력 시 버튼 비활성화 확인
- [x] 댓글 입력 시 댓글 리스트 하단에 추가됨 확인
- [x] 이미지 삽입 후 마크다운 적용 여부 확인
- [x] 글자 수 표시 애니메이션 확인
- [ ] 편집 기능은 로그인 기능 구현 이후 적용 예정

## 🧠 회고/고민

###  1. 텍스트 입력창 높이 조절에 대한 고민과 결정

#### 배경

`CommentInputSection` 컴포넌트는 댓글 작성과 이슈 생성 등 다양한 맥락에서 재사용되기 때문에,  
입력창의 **초기 높이와 자동 확장 기능**을 유연하게 제어할 수 있어야 했습니다.


#### 주요 고민

1. **초기 높이 설정 방식**
   - 이슈 작성 페이지에서는 넉넉한 입력 공간이 필요함 (예: `initialHeight = 300`)
   - 상세 페이지의 댓글 작성 영역에서는 작게 시작해서 필요한 만큼만 확장되는 것이 자연스러움

2. **자동 높이 조절 방식**
   - CSS만으로는 `scrollHeight` 기반 자동 높이 조절이 불가능함
   - JS를 활용해 `textarea.style.height`를 `scrollHeight`로 갱신하는 방식이 필요함

3. **외부에서 높이 제어 여부**
   - 하나의 컴포넌트를 다양한 환경에서 유연하게 사용하려면 외부에서 높이를 지정할 수 있어야 함
   - 이를 위해 `initialHeight`, `maxHeight` prop을 도입하는 방안을 고려함


#### 최종 선택

- `initialHeight`, `maxHeight`를 prop으로 받아 외부에서 높이를 유연하게 설정할 수 있도록 설계
- 입력값 변화에 따라 `scrollHeight`를 기준으로 자동으로 높이가 조절되도록 JS 기반 resize 로직을 구현
- CSS에서는 `height: auto`, `overflow: hidden`, `resize: none`을 설정하여 스크롤 없이 자연스럽게 확장되도록 처리


#### 적용 결과

- **이슈 생성 페이지**: `initialHeight=300`으로 넉넉한 초기 공간 제공
- **댓글 작성 영역**: `initialHeight=80`으로 작게 시작하여 글자 수에 따라 부드럽게 확장
- **`maxHeight` 지원**: 필요 시 최대 높이 제한을 걸어 UX 제어 가능

## 🔗 참고 자료

- GitHub 이슈 작성 UI 및 댓글 UI 동작 방식 참고

closes #158 