### PR TITLE
[Fix] 토큰 만료 판단 로직 오류 수정 및 토큰 관리 유틸 통합

### DIFF
--- a/frontend/src/features/auth/components/ProtectedRoute.tsx
+++ b/frontend/src/features/auth/components/ProtectedRoute.tsx
@@ -1,11 +1,12 @@
 import { Navigate } from 'react-router-dom';
+import { getAccessTokenPair } from '@/features/auth/utils/tokens';
 
 export default function ProtectedRoute({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const token = localStorage.getItem('accessToken');
+  const { token } = getAccessTokenPair();
 
   if (!token) {
     return <Navigate to="/login" replace />;

--- a/frontend/src/features/auth/utils/tokens.ts
+++ b/frontend/src/features/auth/utils/tokens.ts
@@ -1,7 +1,7 @@
-const TOKEN_KEY = 'access_token';
-const TOKEN_TYPE_KEY = 'token_type';
-const ISSUED_AT_KEY = 'access_token_issued_at';
-const TOKEN_LIFETIME = 30 * 60 * 1000; // 30분(ms)
+export const TOKEN_KEY = 'access_token';
+export const TOKEN_TYPE_KEY = 'token_type';
+export const ISSUED_AT_KEY = 'access_token_issued_at';
+export const TOKEN_LIFETIME = 30 * 60 * 1000; // 30분(ms)
 
 export function setAccessToken(token: string, tokenType: string) {
   localStorage.setItem(TOKEN_KEY, token);

--- a/frontend/src/features/auth/utils/tokens.ts
+++ b/frontend/src/features/auth/utils/tokens.ts
@@ -1,6 +1,6 @@
-const TOKEN_KEY = 'accessToken';
-const TOKEN_TYPE_KEY = 'tokenType';
-const ISSUED_AT_KEY = 'accessTokenIssuedAt';
+const TOKEN_KEY = 'access_token';
+const TOKEN_TYPE_KEY = 'token_type';
+const ISSUED_AT_KEY = 'access_token_issued_at';
 const TOKEN_LIFETIME = 30 * 60 * 1000; // 30분(ms)
 
 export function setAccessToken(token: string, tokenType: string) {
@@ -11,8 +11,14 @@ export function setAccessToken(token: string, tokenType: string) {
   setupAutoLogout();
 }
 
-export function getAccessToken(): string | null {
-  return localStorage.getItem(TOKEN_KEY);
+export function getAccessTokenPair(): {
+  token: string | null;
+  tokenType: string | null;
+} {
+  return {
+    token: localStorage.getItem(TOKEN_KEY),
+    tokenType: localStorage.getItem(TOKEN_TYPE_KEY),
+  };
 }
 
 export function removeAccessToken() {

--- a/frontend/src/pages/AuthCallbackPage.tsx
+++ b/frontend/src/pages/AuthCallbackPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { setAccessToken } from '@/features/auth/utils/tokens';
 
 export default function AuthCallbackPage() {
   const navigate = useNavigate();
@@ -10,8 +11,7 @@ export default function AuthCallbackPage() {
     const tokenType = hashParams.get('token_type');
 
     if (token && tokenType) {
-      localStorage.setItem('accessToken', token);
-      localStorage.setItem('tokenType', tokenType);
+      setAccessToken(token, tokenType);
 
       window.history.replaceState(null, '', '/');
       navigate('/');

--- a/frontend/src/shared/utils/fetchWithAuth.ts
+++ b/frontend/src/shared/utils/fetchWithAuth.ts
@@ -1,14 +1,14 @@
 import {
   isAccessTokenStillValid,
   removeAccessToken,
+  getAccessTokenPair,
 } from '@/features/auth/utils/tokens';
 
 export default async function fetchWithAuth(
   input: RequestInfo,
   init?: RequestInit,
 ) {
-  const token = localStorage.getItem('accessToken');
-  const tokenType = localStorage.getItem('tokenType');
+  const { token, tokenType } = getAccessTokenPair();
 
   if (!token || !isAccessTokenStillValid()) {
     removeAccessToken();

--- a/frontend/src/test/utils/mockValidAccessToken.ts
+++ b/frontend/src/test/utils/mockValidAccessToken.ts
@@ -1,5 +1,11 @@
+import {
+  TOKEN_KEY,
+  TOKEN_TYPE_KEY,
+  ISSUED_AT_KEY,
+} from '@/features/auth/utils/tokens';
+
 export default function mockValidAccessToken() {
-  localStorage.setItem('accessToken', 'mock-token');
-  localStorage.setItem('tokenType', 'Bearer');
-  localStorage.setItem('accessTokenIssuedAt', Date.now().toString());
+  localStorage.setItem(TOKEN_KEY, 'mock-token');
+  localStorage.setItem(TOKEN_TYPE_KEY, 'Bearer');
+  localStorage.setItem(ISSUED_AT_KEY, Date.now().toString());
 }


### PR DESCRIPTION
## 📌 PR 제목

[Fix] 토큰 만료 판단 로직 오류 수정 및 토큰 관리 유틸 통합


## ✅ 작업 요약

- `issuedAt`이 저장되지 않아 토큰이 항상 만료로 간주되던 문제를 해결
- `fetchWithAuth` 요청 시 유효한 토큰이어도 계속 로그아웃되는 버그 수정
- 토큰 관련 키 값을 `tokens.ts`에서 상수로 관리하도록 통일
- 토큰과 토큰 타입을 함께 반환하는 `getAccessTokenPair()` 유틸 함수 추가
- 기존에 분산되어 있던 `localStorage` 접근 로직 제거 및 통합

## ✅ 테스트 확인

- [x] `setAccessToken()`을 통해 토큰 발급 시 `issuedAt`이 함께 저장되는지 확인
- [x] `isAccessTokenStillValid()`가 정상 작동하여 fetch 요청 전에 토큰 유효성 검사 통과
- [x] `fetchWithAuth()`에서 더 이상 불필요하게 로그인 페이지로 리다이렉트되지 않음
- [x] `getAccessTokenPair()`를 통해 token과 tokenType이 정상 반환되는지 확인

## 🧠 회고/고민

###  로그인되지 않던 문제의 디버깅 과정

- 배포 환경에서 로그인 직후 깜빡이는 순간의 리다이렉트 주소를 파싱해 확인했고, 전달받은 accessToken과 tokenType이 정상적으로 포함되어 있는지 확인했습니다.
- 이후에도 계속 로그인 페이지로 리다이렉트되는 현상을 기반으로, 어떤 조건에서 `/login`으로 이동시키는지를 `fetchWithAuth`와 `isAccessTokenStillValid()` 내부 로직을 통해 추적했습니다.

### 문제의 배경

- `setAccessToken()`을 사용하지 않고 직접 `localStorage`에 accessToken만 저장한 경우, `issuedAt` 값이 빠져 `isAccessTokenStillValid()`가 항상 `false`를 반환했습니다.
- 이로 인해 `fetchWithAuth()`에서 모든 요청이 만료로 간주되어, 사용자가 매번 `/login` 페이지로 강제 이동되는 문제가 발생했습니다.
- 또한 여러 컴포넌트나 유틸에서 `localStorage.getItem('access_token')` 같은 하드코딩이 분산되어 있어, 관리가 어려웠고 실수 가능성도 높았습니다.

### 해결 방법

- `issuedAt`을 포함하지 않으면 유효성 검사가 무력화되므로, 반드시 `setAccessToken()`을 사용하도록 모든 토큰 저장 로직을 통일했습니다.
- `tokens.ts` 내부에 상수 (`ACCESS_TOKEN_KEY`, `TOKEN_TYPE_KEY`, `ISSUED_AT_KEY`)를 정의하고, 이를 사용하는 유틸 함수(`getAccessToken`, `removeAccessToken` 등)만 통해 로컬스토리지를 다루도록 구조를 리팩토링했습니다.
- 기존 `getAccessToken()`은 token만 반환해 `tokenType`을 별도로 가져와야 했는데, 이를 함께 가져오는 `getAccessTokenPair()`로 확장하여 fetch 로직에서도 코드 일관성과 간결성을 확보했습니다.

closes #172 
