### PR TITLE
[Feature] 로그인 유저 정보 디코딩 및 작성자만 이슈 삭제 가능 처리

### DIFF
--- a/frontend/src/features/auth/hooks/useCurrentUser.ts
+++ b/frontend/src/features/auth/hooks/useCurrentUser.ts
@@ -1,0 +1,14 @@
+import { useMemo } from 'react';
+import { decodeAccessToken } from '@/shared/utils/decodeAccessToken';
+import { getAccessTokenPair } from '@/features/auth/utils/tokens';
+
+export function useCurrentUser() {
+  const { token } = getAccessTokenPair();
+
+  const user = useMemo(() => {
+    if (!token) return null;
+    return decodeAccessToken(token);
+  }, [token]);
+
+  return user;
+}

--- a/frontend/src/features/issue/api/deleteIssue.ts
+++ b/frontend/src/features/issue/api/deleteIssue.ts
@@ -1,0 +1,26 @@
+import { API } from '@/shared/constants/api';
+import fetchWithAuth from '@/shared/utils/fetchWithAuth';
+
+export default async function deleteIssue(id: number): Promise<void> {
+  const response = await fetchWithAuth(`${API.ISSUES}/${id}`, {
+    method: 'DELETE',
+  });
+
+  const statusCodeHandler: Record<number, () => Promise<void>> = {
+    204: () => Promise.resolve(),
+    401: () => {
+      window.location.href = '/login';
+      return Promise.reject(new Error('로그인이 필요합니다.'));
+    },
+    403: () => Promise.reject(new Error('삭제 권한이 없습니다.')),
+    404: () => Promise.reject(new Error('존재하지 않는 이슈입니다.')),
+    500: () => Promise.reject(new Error('서버 오류가 발생했습니다.')),
+  };
+
+  const defaultHandler = () =>
+    Promise.reject(
+      new Error(`예상치 못한 오류가 발생했습니다 (status: ${response.status})`),
+    );
+
+  return (statusCodeHandler[response.status] ?? defaultHandler)();
+}

--- a/frontend/src/features/issue/components/detail/IssueDeleteButton.tsx
+++ b/frontend/src/features/issue/components/detail/IssueDeleteButton.tsx
@@ -1,0 +1,60 @@
+import { useDeleteIssue } from '@/features/issue/hooks/useDeleteIssue';
+import TrashIcon from '@/assets/icons/trash.svg?react';
+import styled from '@emotion/styled';
+
+interface IssueDeleteButtonProps {
+  issueId: number;
+}
+
+export default function IssueDeleteButton({ issueId }: IssueDeleteButtonProps) {
+  const { mutate: deleteIssue, isPending } = useDeleteIssue();
+
+  const handleClick = () => {
+    deleteIssue(issueId);
+  };
+
+  return (
+    <TabButton onClick={handleClick} disabled={isPending}>
+      <IconWrapper>
+        <TrashIcon />
+      </IconWrapper>
+      <Label>이슈 삭제</Label>
+    </TabButton>
+  );
+}
+
+const TabButton = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 0;
+  margin-right: 16px;
+  color: ${({ theme }) => theme.danger.text.default};
+  ${({ theme }) => theme.typography.availableMedium12};
+
+  cursor: pointer;
+
+  &:hover {
+    opacity: 0.8;
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;
+
+const IconWrapper = styled.span`
+  display: flex;
+  align-items: center;
+  color: inherit;
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
+`;
+
+const Label = styled.span`
+  color: inherit;
+`;

--- a/frontend/src/features/issue/hooks/useDeleteIssue.ts
+++ b/frontend/src/features/issue/hooks/useDeleteIssue.ts
@@ -1,0 +1,14 @@
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import deleteIssue from '../api/deleteIssue';
+
+export function useDeleteIssue() {
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: deleteIssue,
+    onSuccess: () => {
+      navigate('/');
+    },
+  });
+}

--- a/frontend/src/pages/IssueDetailPage.tsx
+++ b/frontend/src/pages/IssueDetailPage.tsx
@@ -1,6 +1,5 @@
 import { useParams } from 'react-router-dom';
 import styled from '@emotion/styled';
-import TrashIcon from '@/assets/icons/trash.svg?react';
 import useIssueAssignees from '@/features/issue/hooks/useIssueAssignees';
 import useIssueLabels from '@/features/issue/hooks/useIssueLabels';
 import useIssueMilestone from '@/features/issue/hooks/useIssueMilestone';
@@ -11,6 +10,7 @@ import Divider from '@/shared/components/Divider';
 import IssueHeader from '@/features/issue/components/detail/IssueHeader';
 import IssueMainSection from '@/features/issue/components/detail/IssueMainSection';
 import IssueSidebar from '@/shared/components/sidebar';
+import IssueDeleteButton from '@/features/issue/components/detail/IssueDeleteButton';
 import VerticalStack from '@/layouts/VerticalStack';
 
 export default function IssueDetailPage() {
@@ -107,7 +107,7 @@ export default function IssueDetailPage() {
             selectedMilestoneId={selectedMilestoneId}
             onSelectMilestone={() => {}}
           />
-          <TabItem icon={<TrashIcon />} label="이슈 삭제" />
+          <IssueDeleteButton issueId={issueId} />
         </SideSection>
       </MainArea>
     </VerticalStack>
@@ -125,50 +125,4 @@ const SideSection = styled.div`
   flex-direction: column;
   align-items: flex-end;
   gap: 16px;
-`;
-
-interface TabItemProps {
-  icon: React.ReactNode;
-  label: string;
-}
-
-// TODO 공용으로 분리 및 onClick 추가
-function TabItem({ icon, label }: TabItemProps) {
-  return (
-    <TabButton>
-      <IconWrapper>{icon}</IconWrapper>
-      <Label>{label}</Label>
-    </TabButton>
-  );
-}
-
-const TabButton = styled.button<{ active?: boolean }>`
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 8px 0;
-  margin-right: 16px;
-  color: ${({ theme }) => theme.danger.text.default};
-  ${({ theme }) => theme.typography.availableMedium12};
-
-  cursor: pointer;
-
-  &:hover {
-    opacity: 0.8;
-  }
-`;
-
-const IconWrapper = styled.span`
-  display: flex;
-  align-items: center;
-  color: inherit;
-
-  svg {
-    width: 16px;
-    height: 16px;
-  }
-`;
-
-const Label = styled.span`
-  color: inherit;
 `;

--- a/frontend/src/pages/IssueDetailPage.tsx
+++ b/frontend/src/pages/IssueDetailPage.tsx
@@ -6,6 +6,8 @@ import useIssueMilestone from '@/features/issue/hooks/useIssueMilestone';
 import useIssueDetail from '@/features/issue/hooks/useIssueDetail';
 import useIssueComments from '@/features/issue/hooks/useIssueComments';
 import usePatchIssueState from '@/features/issue/hooks/usePatchIssueState';
+import { useCurrentUser } from '@/features/auth/hooks/useCurrentUser';
+
 import Divider from '@/shared/components/Divider';
 import IssueHeader from '@/features/issue/components/detail/IssueHeader';
 import IssueMainSection from '@/features/issue/components/detail/IssueMainSection';
@@ -16,6 +18,8 @@ import VerticalStack from '@/layouts/VerticalStack';
 export default function IssueDetailPage() {
   const { id } = useParams();
   const issueId = Number(id);
+  const currentUser = useCurrentUser();
+
   const { mutate: toggleIssueState, isPending: isToggleLoading } =
     usePatchIssueState(issueId);
 
@@ -81,6 +85,8 @@ export default function IssueDetailPage() {
   const selectedLabelIds = issueLabels.map(label => label.id);
   const selectedMilestoneId = issueMilestone?.id ?? null;
 
+  const isAuthor = currentUser?.nickname === issueDetail.author.nickname;
+
   return (
     <VerticalStack>
       <IssueHeader
@@ -107,7 +113,7 @@ export default function IssueDetailPage() {
             selectedMilestoneId={selectedMilestoneId}
             onSelectMilestone={() => {}}
           />
-          <IssueDeleteButton issueId={issueId} />
+          {isAuthor && <IssueDeleteButton issueId={issueId} />}
         </SideSection>
       </MainArea>
     </VerticalStack>

--- a/frontend/src/shared/utils/decodeAccessToken.ts
+++ b/frontend/src/shared/utils/decodeAccessToken.ts
@@ -1,0 +1,25 @@
+export interface DecodedAccessToken {
+  nickname: string;
+  profileImageUrl: string;
+  exp: number;
+}
+
+export function decodeAccessToken(token: string): DecodedAccessToken | null {
+  try {
+    const base64Url = token.split('.')[1];
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    const jsonPayload = decodeURIComponent(
+      atob(base64)
+        .split('')
+        .map(c => `%${('00' + c.charCodeAt(0).toString(16)).slice(-2)}`)
+        .join(''),
+    );
+
+    const { nickname, profileImageUrl, exp } = JSON.parse(jsonPayload);
+
+    return { nickname, profileImageUrl, exp };
+  } catch (e) {
+    console.error('JWT 디코딩 실패:', e);
+    return null;
+  }
+}


### PR DESCRIPTION
## 📌 PR 제목

[Feature] 로그인 유저 정보 디코딩 및 작성자만 이슈 삭제 가능 처리


## ✅ 작업 요약

- access token에서 유저 정보를 디코딩하는 `decodeAccessToken` 유틸 함수 구현
- 디코딩된 정보를 캐싱하여 반환하는 `useCurrentUser` 커스텀 훅 구현
- 삭제 API 요청 함수 `deleteIssue` 구현 및 에러 상태 코드별 예외 처리
- 삭제 요청을 수행하는 `useDeleteIssue` 훅 구현 (성공 시 `/`로 리다이렉트)
- 삭제 버튼을 `IssueDeleteButton`으로 분리하고, 작성자인 경우에만 노출되도록 조건 분기 적용

### 추후 작업 예정
related: #175
삭제 버튼을 누를 때, 현재는 바로 삭제가 되지만
**추후 전역 모달 시스템을 구현한 뒤에는 "정말 삭제하시겠습니까?"와 같은 confirm 모달로 대체할 계획**입니다.  
이 confirm 모달은 Portal 기반으로 구현하여 재사용성과 UX 일관성을 확보할 예정입니다.



## ✅ 테스트 확인

- [x] `decodeAccessToken` 유틸 정상 작동 및 유저 정보 추출 확인
- [x] `useCurrentUser` 훅 캐싱 동작 정상 확인
- [x] 작성자일 경우에만 삭제 버튼이 UI에 렌더링되는지 확인
- [x] 삭제 API 호출 시 상태 코드별 예외 처리가 올바르게 동작하는지 확인
- [x] 삭제 성공 시 메인 페이지(`/`)로 정상 리다이렉션 되는지 확인

---

## 🧠 회고/고민

이번 작업에서 가장 큰 고민은 **로그인된 유저의 정보를 어떤 방식으로 관리할 것인가**였습니다.

초기에는 access token을 디코딩한 후 얻은 유저 정보(`nickname`, `profileImageUrl`, `exp`)를 `user_info`라는 별도의 키로 로컬스토리지에 저장하고, 이를 전역 상태로 불러와 사용하는 구조를 고려했습니다. 하지만 이 접근은 다음과 같은 문제점을 가지고 있었습니다:

- 토큰과 유저 정보가 **이중으로 저장되면서 상태 정합성이 깨질 가능성**
- 토큰이 갱신되었을 때 `user_info`도 함께 동기화해줘야 하는 **관리 부담**
- 실수로 캐싱된 유저 정보가 오래 남아있어 **실제 로그인 상태와 불일치할 수 있음**

이러한 고민 끝에 다음과 같은 방식으로 구조를 정리했습니다:

- 로컬스토리지에는 **access token만 저장**
- 유저 정보는 **매번 token을 디코딩해서 얻되**, 디코딩 비용을 줄이기 위해 `useMemo`로 캐싱
- 이 로직을 `useCurrentUser` 커스텀 훅으로 캡슐화하여, 어느 컴포넌트에서든 유저 정보를 안전하고 일관되게 사용할 수 있도록 설계

이를 통해 상태 중복 문제를 제거하고, 유저 정보 접근의 신뢰성과 유지보수성을 높일 수 있었습니다.

---

## 🔗 참고 자료

- (jwt 디코딩 사이트)](https://jwt.io/)

closes #165 