### PR TITLE
[Feature] 마일스톤 생성/수정 기능 추가

### DIFF
--- a/backend/src/main/java/elbin_bank/issue_tracker/label/application/command/LabelCommandService.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/label/application/command/LabelCommandService.java
@@ -1,6 +1,5 @@
 package elbin_bank.issue_tracker.label.application.command;
 
-import elbin_bank.issue_tracker.comment.exception.CommentNotFoundException;
 import elbin_bank.issue_tracker.label.application.query.repository.LabelQueryRepository;
 import elbin_bank.issue_tracker.label.domain.Label;
 import elbin_bank.issue_tracker.label.domain.LabelCommandRepository;
@@ -34,5 +33,10 @@ public class LabelCommandService {
                 .orElseThrow(() -> new LabelNotFoundException(id));
 
         labelCommandRepository.update(label, labelUpdateRequestDto);
+    }
+
+    @Transactional
+    public void deleteLabel(Long id) {
+        labelCommandRepository.deleteById(id);
     }
 }

--- a/backend/src/main/java/elbin_bank/issue_tracker/label/application/command/LabelCommandService.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/label/application/command/LabelCommandService.java
@@ -29,7 +29,7 @@ public class LabelCommandService {
 
     @Transactional
     public void updateLabel(LabelUpdateRequestDto labelUpdateRequestDto, Long id) {
-        LabelProjection label = Optional.ofNullable(labelQueryRepository.findById(id))
+        LabelProjection label = labelQueryRepository.findById(id)
                 .orElseThrow(() -> new LabelNotFoundException(id));
 
         labelCommandRepository.update(label, labelUpdateRequestDto);

--- a/backend/src/main/java/elbin_bank/issue_tracker/label/application/query/repository/LabelQueryRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/label/application/query/repository/LabelQueryRepository.java
@@ -4,10 +4,11 @@ import elbin_bank.issue_tracker.label.infrastructure.query.projection.LabelProje
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public interface LabelQueryRepository {
 
-    LabelProjection findById(Long id);
+    Optional<LabelProjection> findById(Long id);
 
     Map<Long, List<LabelProjection>> findByIssueIds(List<Long> issueIds);
 

--- a/backend/src/main/java/elbin_bank/issue_tracker/label/domain/LabelCommandRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/label/domain/LabelCommandRepository.java
@@ -15,4 +15,5 @@ public interface LabelCommandRepository {
 
     void update(LabelProjection label, LabelUpdateRequestDto labelUpdateRequestDto);
 
+    void deleteById(Long id);
 }

--- a/backend/src/main/java/elbin_bank/issue_tracker/label/infrastructure/command/JdbcLabelCommandRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/label/infrastructure/command/JdbcLabelCommandRepository.java
@@ -86,4 +86,16 @@ public class JdbcLabelCommandRepository implements LabelCommandRepository {
         jdbc.update(sql, params);
     }
 
+    @Override
+    public void deleteById(Long id) {
+        String sql = """
+                UPDATE label
+                SET deleted_at = CURRENT_TIMESTAMP
+                WHERE id = :id
+                """;
+
+        var params = new MapSqlParameterSource().addValue("id", id);
+        jdbc.update(sql, params);
+    }
+
 }

--- a/backend/src/main/java/elbin_bank/issue_tracker/label/presentation/command/LabelCommandController.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/label/presentation/command/LabelCommandController.java
@@ -29,5 +29,12 @@ public class LabelCommandController {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteLabel(@PathVariable("id") Long id) {
+        labelCommandService.deleteLabel(id);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
 
 }

--- a/backend/src/main/java/elbin_bank/issue_tracker/milestone/application/command/MilestoneCommandService.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/milestone/application/command/MilestoneCommandService.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -30,7 +29,7 @@ public class MilestoneCommandService {
 
     @Transactional
     public void updateMilestone(MilestoneUpdateRequestDto milestoneUpdateRequestDto, Long id) {
-        MilestoneUpdateProjection milestone = Optional.ofNullable(milestoneQueryRepository.findById(id))
+        MilestoneUpdateProjection milestone = milestoneQueryRepository.findById(id)
                 .orElseThrow(() -> new MilestoneNotFoundException(id));
 
         LocalDate expiredAt = milestoneUpdateRequestDto.expiredAt() != null ? LocalDate.parse(milestoneUpdateRequestDto.expiredAt()) : null;

--- a/backend/src/main/java/elbin_bank/issue_tracker/milestone/application/command/MilestoneCommandService.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/milestone/application/command/MilestoneCommandService.java
@@ -1,0 +1,41 @@
+package elbin_bank.issue_tracker.milestone.application.command;
+
+import elbin_bank.issue_tracker.milestone.application.query.repository.MilestoneQueryRepository;
+import elbin_bank.issue_tracker.milestone.domain.Milestone;
+import elbin_bank.issue_tracker.milestone.domain.MilestoneCommandRepository;
+import elbin_bank.issue_tracker.milestone.exception.MilestoneNotFoundException;
+import elbin_bank.issue_tracker.milestone.infrastructure.query.projection.MilestoneUpdateProjection;
+import elbin_bank.issue_tracker.milestone.presentation.command.dto.request.MilestoneCreateRequestDto;
+import elbin_bank.issue_tracker.milestone.presentation.command.dto.request.MilestoneUpdateRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MilestoneCommandService {
+
+    private final MilestoneCommandRepository milestoneCommandRepository;
+    private final MilestoneQueryRepository milestoneQueryRepository;
+
+    @Transactional
+    public void createMilestone(MilestoneCreateRequestDto milestoneCreateRequestDto) {
+        Milestone milestone = Milestone.of(milestoneCreateRequestDto.title(), milestoneCreateRequestDto.expiredAt(), milestoneCreateRequestDto.description());
+
+        milestoneCommandRepository.save(milestone);
+    }
+
+    @Transactional
+    public void updateMilestone(MilestoneUpdateRequestDto milestoneUpdateRequestDto, Long id) {
+        MilestoneUpdateProjection milestone = Optional.ofNullable(milestoneQueryRepository.findById(id))
+                .orElseThrow(() -> new MilestoneNotFoundException(id));
+
+        LocalDate expiredAt = milestoneUpdateRequestDto.expiredAt() != null ? LocalDate.parse(milestoneUpdateRequestDto.expiredAt()) : null;
+
+        milestoneCommandRepository.update(milestone, milestoneUpdateRequestDto.title(), milestoneUpdateRequestDto.description(), expiredAt);
+    }
+
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/milestone/application/command/MilestoneCommandService.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/milestone/application/command/MilestoneCommandService.java
@@ -38,4 +38,8 @@ public class MilestoneCommandService {
         milestoneCommandRepository.update(milestone, milestoneUpdateRequestDto.title(), milestoneUpdateRequestDto.description(), expiredAt);
     }
 
+    @Transactional
+    public void deleteMilestone(Long id) {
+        milestoneCommandRepository.deleteById(id);
+    }
 }

--- a/backend/src/main/java/elbin_bank/issue_tracker/milestone/application/query/repository/MilestoneQueryRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/milestone/application/query/repository/MilestoneQueryRepository.java
@@ -2,11 +2,14 @@ package elbin_bank.issue_tracker.milestone.application.query.repository;
 
 import elbin_bank.issue_tracker.milestone.infrastructure.query.projection.MilestoneProjection;
 import elbin_bank.issue_tracker.milestone.infrastructure.query.projection.MilestoneShortProjection;
+import elbin_bank.issue_tracker.milestone.infrastructure.query.projection.MilestoneUpdateProjection;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface MilestoneQueryRepository {
+
+    MilestoneUpdateProjection findById(Long id);
 
     List<MilestoneShortProjection> findAllForSelectBox();
 

--- a/backend/src/main/java/elbin_bank/issue_tracker/milestone/application/query/repository/MilestoneQueryRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/milestone/application/query/repository/MilestoneQueryRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 public interface MilestoneQueryRepository {
 
-    MilestoneUpdateProjection findById(Long id);
+    Optional<MilestoneUpdateProjection> findById(Long id);
 
     List<MilestoneShortProjection> findAllForSelectBox();
 

--- a/backend/src/main/java/elbin_bank/issue_tracker/milestone/domain/Milestone.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/milestone/domain/Milestone.java
@@ -24,4 +24,9 @@ public class Milestone extends BaseEntity {
     private String description;
     private LocalDate expiredAt;
 
+    public static Milestone of(String title, String expiredAt, String description) {
+        LocalDate expiredDate = expiredAt != null ? LocalDate.parse(expiredAt) : null;
+        return new Milestone(null, false, title, description, expiredDate); // id는 DB에서 생성
+    }
+
 }

--- a/backend/src/main/java/elbin_bank/issue_tracker/milestone/domain/MilestoneCommandRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/milestone/domain/MilestoneCommandRepository.java
@@ -10,4 +10,5 @@ public interface MilestoneCommandRepository {
 
     void update(MilestoneUpdateProjection milestone, String title, String description, LocalDate expiredAt);
 
+    void deleteById(Long id);
 }

--- a/backend/src/main/java/elbin_bank/issue_tracker/milestone/domain/MilestoneCommandRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/milestone/domain/MilestoneCommandRepository.java
@@ -1,0 +1,13 @@
+package elbin_bank.issue_tracker.milestone.domain;
+
+import elbin_bank.issue_tracker.milestone.infrastructure.query.projection.MilestoneUpdateProjection;
+
+import java.time.LocalDate;
+
+public interface MilestoneCommandRepository {
+
+    void save(Milestone milestone);
+
+    void update(MilestoneUpdateProjection milestone, String title, String description, LocalDate expiredAt);
+
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/milestone/exception/MilestoneNotFoundException.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/milestone/exception/MilestoneNotFoundException.java
@@ -1,0 +1,7 @@
+package elbin_bank.issue_tracker.milestone.exception;
+
+public class MilestoneNotFoundException extends RuntimeException {
+    public MilestoneNotFoundException(Long id) {
+        super("Could not find label with id " + id);
+    }
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/milestone/exception/MilestoneNotFoundException.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/milestone/exception/MilestoneNotFoundException.java
@@ -2,6 +2,6 @@ package elbin_bank.issue_tracker.milestone.exception;
 
 public class MilestoneNotFoundException extends RuntimeException {
     public MilestoneNotFoundException(Long id) {
-        super("Could not find label with id " + id);
+        super("Could not find milestone with id " + id);
     }
 }

--- a/backend/src/main/java/elbin_bank/issue_tracker/milestone/infrastructure/command/JdbcMilestoneCommandRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/milestone/infrastructure/command/JdbcMilestoneCommandRepository.java
@@ -3,7 +3,6 @@ package elbin_bank.issue_tracker.milestone.infrastructure.command;
 import elbin_bank.issue_tracker.milestone.domain.Milestone;
 import elbin_bank.issue_tracker.milestone.domain.MilestoneCommandRepository;
 import elbin_bank.issue_tracker.milestone.infrastructure.query.projection.MilestoneUpdateProjection;
-import elbin_bank.issue_tracker.milestone.presentation.command.dto.request.MilestoneUpdateRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -49,6 +48,18 @@ public class JdbcMilestoneCommandRepository implements MilestoneCommandRepositor
                 .addValue("expiredAt", expiredAt)
                 .addValue("id", milestone.id());
 
+        jdbc.update(sql, params);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        String sql = """
+                UPDATE milestone
+                SET deleted_at = CURRENT_TIMESTAMP
+                WHERE id = :id
+                """;
+
+        var params = new MapSqlParameterSource().addValue("id", id);
         jdbc.update(sql, params);
     }
 

--- a/backend/src/main/java/elbin_bank/issue_tracker/milestone/infrastructure/command/JdbcMilestoneCommandRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/milestone/infrastructure/command/JdbcMilestoneCommandRepository.java
@@ -1,0 +1,56 @@
+package elbin_bank.issue_tracker.milestone.infrastructure.command;
+
+import elbin_bank.issue_tracker.milestone.domain.Milestone;
+import elbin_bank.issue_tracker.milestone.domain.MilestoneCommandRepository;
+import elbin_bank.issue_tracker.milestone.infrastructure.query.projection.MilestoneUpdateProjection;
+import elbin_bank.issue_tracker.milestone.presentation.command.dto.request.MilestoneUpdateRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+
+@Repository
+@RequiredArgsConstructor
+public class JdbcMilestoneCommandRepository implements MilestoneCommandRepository {
+
+    private final NamedParameterJdbcTemplate jdbc;
+
+    @Override
+    public void save(Milestone milestone) {
+        String sql = """
+                    INSERT INTO milestone
+                      (is_closed, title, description, expired_at)
+                    VALUES
+                      (:isClosed, :title, :description, :expiredAt)
+                """;
+
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("isClosed", false)
+                .addValue("title", milestone.getTitle())
+                .addValue("description", milestone.getDescription())
+                .addValue("expiredAt", milestone.getExpiredAt());
+
+        jdbc.update(sql, params);
+    }
+
+    @Override
+    public void update(MilestoneUpdateProjection milestone, String title, String description, LocalDate expiredAt) {
+        String sql = """
+                    UPDATE milestone
+                       SET title = :title, description = :description, expired_at = :expiredAt, updated_at = NOW()
+                    WHERE id = :id
+                """;
+
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("title", title)
+                .addValue("description", description)
+                .addValue("expiredAt", expiredAt)
+                .addValue("id", milestone.id());
+
+        jdbc.update(sql, params);
+    }
+
+
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/milestone/infrastructure/query/JdbcMilestoneQueryRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/milestone/infrastructure/query/JdbcMilestoneQueryRepository.java
@@ -3,6 +3,7 @@ package elbin_bank.issue_tracker.milestone.infrastructure.query;
 import elbin_bank.issue_tracker.milestone.application.query.repository.MilestoneQueryRepository;
 import elbin_bank.issue_tracker.milestone.infrastructure.query.projection.MilestoneProjection;
 import elbin_bank.issue_tracker.milestone.infrastructure.query.projection.MilestoneShortProjection;
+import elbin_bank.issue_tracker.milestone.infrastructure.query.projection.MilestoneUpdateProjection;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -18,6 +19,27 @@ public class JdbcMilestoneQueryRepository implements MilestoneQueryRepository {
 
     public JdbcMilestoneQueryRepository(NamedParameterJdbcTemplate jdbc) {
         this.jdbc = jdbc;
+    }
+
+    @Override
+    public MilestoneUpdateProjection findById(Long id) {
+        String sql = """
+                SELECT id,
+                       title,
+                       expired_at,
+                       description
+                  FROM milestone
+                 WHERE id = :id
+                """;
+
+        var params = new MapSqlParameterSource("id", id);
+
+        return jdbc.queryForObject(sql, params, (rs, rowNum) -> new MilestoneUpdateProjection(
+                rs.getLong("id"),
+                rs.getString("title"),
+                rs.getString("expired_at"),
+                rs.getString("description")
+        ));
     }
 
     @Override

--- a/backend/src/main/java/elbin_bank/issue_tracker/milestone/infrastructure/query/JdbcMilestoneQueryRepository.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/milestone/infrastructure/query/JdbcMilestoneQueryRepository.java
@@ -22,7 +22,7 @@ public class JdbcMilestoneQueryRepository implements MilestoneQueryRepository {
     }
 
     @Override
-    public MilestoneUpdateProjection findById(Long id) {
+    public Optional<MilestoneUpdateProjection> findById(Long id) {
         String sql = """
                 SELECT id,
                        title,
@@ -34,12 +34,17 @@ public class JdbcMilestoneQueryRepository implements MilestoneQueryRepository {
 
         var params = new MapSqlParameterSource("id", id);
 
-        return jdbc.queryForObject(sql, params, (rs, rowNum) -> new MilestoneUpdateProjection(
-                rs.getLong("id"),
-                rs.getString("title"),
-                rs.getString("expired_at"),
-                rs.getString("description")
-        ));
+        try{
+            MilestoneUpdateProjection milestoneUpdateProjection = jdbc.queryForObject(sql, params, (rs, rowNum) -> new MilestoneUpdateProjection(
+                    rs.getLong("id"),
+                    rs.getString("title"),
+                    rs.getString("expired_at"),
+                    rs.getString("description")
+            ));
+            return Optional.of(milestoneUpdateProjection);
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
+        }
     }
 
     @Override

--- a/backend/src/main/java/elbin_bank/issue_tracker/milestone/infrastructure/query/projection/MilestoneUpdateProjection.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/milestone/infrastructure/query/projection/MilestoneUpdateProjection.java
@@ -1,0 +1,4 @@
+package elbin_bank.issue_tracker.milestone.infrastructure.query.projection;
+
+public record MilestoneUpdateProjection(long id, String title, String expiredAt, String description) {
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/milestone/presentation/command/MilestoneCommandController.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/milestone/presentation/command/MilestoneCommandController.java
@@ -29,4 +29,11 @@ public class MilestoneCommandController {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
+    @DeleteMapping("{id}")
+    public ResponseEntity<Void> deleteMilestone(@PathVariable Long id) {
+        milestoneCommandService.deleteMilestone(id);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
 }

--- a/backend/src/main/java/elbin_bank/issue_tracker/milestone/presentation/command/MilestoneCommandController.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/milestone/presentation/command/MilestoneCommandController.java
@@ -1,0 +1,32 @@
+package elbin_bank.issue_tracker.milestone.presentation.command;
+
+import elbin_bank.issue_tracker.milestone.application.command.MilestoneCommandService;
+import elbin_bank.issue_tracker.milestone.presentation.command.dto.request.MilestoneCreateRequestDto;
+import elbin_bank.issue_tracker.milestone.presentation.command.dto.request.MilestoneUpdateRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/milestones")
+public class MilestoneCommandController {
+
+    private final MilestoneCommandService milestoneCommandService;
+
+    @PostMapping("")
+    public ResponseEntity<Void> createMilestone(@RequestBody MilestoneCreateRequestDto milestoneCreateRequestDto) {
+        milestoneCommandService.createMilestone(milestoneCreateRequestDto);
+
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PatchMapping("{id}")
+    public ResponseEntity<Void> updateMilestone(@RequestBody MilestoneUpdateRequestDto milestoneUpdateRequestDto, @PathVariable Long id) {
+        milestoneCommandService.updateMilestone(milestoneUpdateRequestDto, id);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/milestone/presentation/command/dto/request/MilestoneCreateRequestDto.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/milestone/presentation/command/dto/request/MilestoneCreateRequestDto.java
@@ -1,0 +1,4 @@
+package elbin_bank.issue_tracker.milestone.presentation.command.dto.request;
+
+public record MilestoneCreateRequestDto(String title, String expiredAt, String description) {
+}

--- a/backend/src/main/java/elbin_bank/issue_tracker/milestone/presentation/command/dto/request/MilestoneUpdateRequestDto.java
+++ b/backend/src/main/java/elbin_bank/issue_tracker/milestone/presentation/command/dto/request/MilestoneUpdateRequestDto.java
@@ -1,0 +1,4 @@
+package elbin_bank.issue_tracker.milestone.presentation.command.dto.request;
+
+public record MilestoneUpdateRequestDto(String title, String expiredAt, String description) {
+}


### PR DESCRIPTION
## **✅ 작업 요약**

- POST /api/v1/milestones 엔드포인트에서 마일스톤 생성 API 구현
- PATCH /api/v1/milestones/{id} 엔드포인트에서 마일스톤 수정 API 구현

## **✅ 테스트 확인**

- POST /api/v1/milestones 요청 시
- PATCH /api/v1/milestones/{id}
    - 요청 받은 정보로 마일스톤이 db에 잘 저장되고 수정되는지 확인 

## **🧠 회고/고민**

마일스톤 수정시 해당 id의 마일스톤을 조회해서 projection으로 변환 후 해당 projection을 넘겨주어 수정하는 식으로 로직을 작성했는데, projection으로 추출하지 않고 그냥 repository에서 쿼리 한번으로 처리했으면 어땠을까 하는 생각이 듭니다.
또한 requestDto를 넘겨 받아 마일스톤을 수정하려했는데, requestDto의 expriedAt 필드가 localdate인 반면 요청으로 넘어오는 expriedAt 필드는 string이라 파싱을 해주어야 하는데 repository 단에서 파싱을 해주려 했지만, 역할상 맞지 않다고 생각하여 service 단에서 처리해었습니다. 