### PR TITLE
[Feature] 댓글 수정 기능 및 입력 영역 리팩토링

### DIFF
--- a/frontend/src/features/issue/api/putComment.ts
+++ b/frontend/src/features/issue/api/putComment.ts
@@ -1,0 +1,31 @@
+import { API } from '@/shared/constants/api';
+import fetchWithAuth from '@/shared/utils/fetchWithAuth';
+import { type PutCommentParams } from '@/features/issue/types/comment';
+
+export default async function PutComment({
+  issueId,
+  commentId,
+  content,
+}: PutCommentParams): Promise<void> {
+  const response = await fetchWithAuth(API.ISSUE_COMMENT(issueId, commentId), {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ content }),
+  });
+
+  if (!response.ok) {
+    switch (response.status) {
+      case 401:
+        window.location.href = '/login';
+        break;
+      case 403:
+        throw new Error('댓글을 수정할 권한이 없습니다.');
+      case 404:
+        throw new Error('댓글을 찾을 수 없습니다.');
+      default:
+        throw new Error('댓글 수정 중 오류가 발생했습니다.');
+    }
+  }
+}

--- a/frontend/src/features/issue/components/detail/CommentDescription.tsx
+++ b/frontend/src/features/issue/components/detail/CommentDescription.tsx
@@ -1,7 +1,34 @@
-import DescriptionBox, {
-  type DescriptionBoxProps,
-} from '@/features/issue/components/detail/DescriptionBox';
+import { useParams } from 'react-router-dom';
+import { useUpdateComment } from '../../hooks/useUpdateComment';
+import { type CommentAuthor } from '@/features/issue/types/issue';
+import DescriptionBox from '@/features/issue/components/detail/DescriptionBox';
 
-export default function CommentDescription(props: DescriptionBoxProps) {
-  return <DescriptionBox {...props} />;
+interface CommentDescriptionProps {
+  content: string | null;
+  author: CommentAuthor;
+  createdAt: string;
+  commentId: number;
+}
+
+export default function CommentDescription({
+  content,
+  author,
+  createdAt,
+  commentId,
+}: CommentDescriptionProps) {
+  const { id: issueId } = useParams();
+  const { mutate } = useUpdateComment(Number(issueId));
+
+  const handleSubmit = (description: string) => {
+    mutate({ commentId, content: description });
+  };
+
+  return (
+    <DescriptionBox
+      content={content}
+      author={author}
+      createdAt={createdAt}
+      onSubmit={handleSubmit}
+    />
+  );
 }

--- a/frontend/src/features/issue/components/detail/CommentEditActionButtons.tsx
+++ b/frontend/src/features/issue/components/detail/CommentEditActionButtons.tsx
@@ -1,0 +1,38 @@
+import styled from '@emotion/styled';
+import Button from '@/shared/components/Button';
+import EditIcon from '@/assets/icons/edit.svg?react';
+
+interface CommentEditActionButtonsProps {
+  onCancel: () => void;
+  onSubmit: () => void;
+  isSubmitDisabled: boolean;
+}
+
+export default function CommentEditActionButtons({
+  onCancel,
+  onSubmit,
+  isSubmitDisabled,
+}: CommentEditActionButtonsProps) {
+  return (
+    <ButtonGroupWrapper>
+      <Button variant="outline" size="small" onClick={onCancel}>
+        취소
+      </Button>
+      <Button
+        size="small"
+        icon={<EditIcon />}
+        disabled={isSubmitDisabled}
+        onClick={onSubmit}
+      >
+        편집 완료
+      </Button>
+    </ButtonGroupWrapper>
+  );
+}
+
+const ButtonGroupWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 16px;
+  margin-top: 12px;
+`;

--- a/frontend/src/features/issue/components/detail/CommentEditor.tsx
+++ b/frontend/src/features/issue/components/detail/CommentEditor.tsx
@@ -8,6 +8,7 @@ import NewCommentActionButton from '@/features/issue/components/detail/NewCommen
 export default function CommentEditor() {
   const { id } = useParams();
   const [comment, setComment] = useState<string>('');
+  const [isFocused, setIsFocused] = useState(false);
 
   const issueId = Number(id);
 
@@ -28,11 +29,16 @@ export default function CommentEditor() {
 
   return (
     <NewCommentWrapper>
-      <CommentInputSection
-        value={comment}
-        onChange={value => setComment(value)}
-        initialHeight={80}
-      />
+      <CommentInputWrapper isFocused={isFocused}>
+        <CommentInputSection
+          value={comment}
+          onChange={value => setComment(value)}
+          isFocused={isFocused}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setIsFocused(false)}
+          initialHeight={80}
+        />
+      </CommentInputWrapper>
 
       <NewCommentActionButton
         isSubmitDisabled={comment.trim() === '' || isPending}
@@ -47,4 +53,20 @@ const NewCommentWrapper = styled.div`
   flex-direction: column;
   justify-content: flex-end;
   gap: 32px;
+`;
+
+const CommentInputWrapper = styled.section<{ isFocused: boolean }>`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  border-radius: ${({ theme }) => theme.radius.medium};
+  overflow: hidden;
+
+  background-color: ${({ isFocused, theme }) =>
+    isFocused ? theme.neutral.surface.default : theme.neutral.surface.bold};
+
+  box-shadow: ${({ isFocused, theme }) =>
+    isFocused ? `0 0 0 1px ${theme.neutral.border.active}` : 'none'};
 `;

--- a/frontend/src/features/issue/components/detail/CommentList.tsx
+++ b/frontend/src/features/issue/components/detail/CommentList.tsx
@@ -12,6 +12,7 @@ export default function CommentList({ comments }: CommentListProps) {
       {comments.map((comment: Comment) => (
         <CommentDescription
           key={comment.id}
+          commentId={comment.id}
           content={comment.content}
           author={comment.author}
           createdAt={comment.createdAt}

--- a/frontend/src/features/issue/components/detail/DescriptionBody.tsx
+++ b/frontend/src/features/issue/components/detail/DescriptionBody.tsx
@@ -20,7 +20,6 @@ export default function DescriptionBody({ content }: DescriptionBodyProps) {
 const StyledContent = styled.div`
   padding: 16px 24px 24px 24px;
   background-color: ${({ theme }) => theme.neutral.surface.strong};
-  border-top: 1px solid ${({ theme }) => theme.neutral.border.default};
   ${({ theme }) => theme.typography.displayMedium16};
   color: ${({ theme }) => theme.neutral.text.default};
 

--- a/frontend/src/features/issue/components/detail/DescriptionBox.tsx
+++ b/frontend/src/features/issue/components/detail/DescriptionBox.tsx
@@ -1,7 +1,11 @@
 import styled from '@emotion/styled';
+import { useState } from 'react';
+import { useCurrentUser } from '@/features/auth/hooks/useCurrentUser';
 import { type CommentAuthor } from '@/features/issue/types/issue';
 import DescriptionHeader from '@/features/issue/components/detail/DescriptionHeader';
 import DescriptionBody from '@/features/issue/components/detail/DescriptionBody';
+import CommentInputSection from '@/features/newIssue/components/CommentInputSection';
+import CommentEditActionButtons from './CommentEditActionButtons';
 
 export interface DescriptionBoxProps {
   content: string | null;
@@ -14,22 +18,66 @@ export default function DescriptionBox({
   author,
   createdAt,
 }: DescriptionBoxProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [description, setDescription] = useState(content || '');
+  const [isFocused, setIsFocused] = useState(false);
+  const currentUser = useCurrentUser();
+
+  const isAuthor = currentUser?.nickname === author.nickname;
+
+  const handleSubmit = () => {
+    // TODO: mutation 연결
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+  };
+
   return (
-    <Wrapper>
-      <DescriptionHeader
-        author={author}
-        createdAt={createdAt}
-        isAuthor={true} //TODO 로그인 기능 구현시 변경
-      />
-      <DescriptionBody content={content} />
-    </Wrapper>
+    <>
+      <EditableCommentBlock isEditing={isEditing}>
+        <DescriptionHeader
+          author={author}
+          createdAt={createdAt}
+          isAuthor={isAuthor}
+          onEditClick={() => setIsEditing(true)}
+        />
+        {isEditing ? (
+          <CommentInputSection
+            value={description}
+            onChange={setDescription}
+            isFocused={isFocused}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
+          />
+        ) : (
+          <DescriptionBody content={description} />
+        )}
+      </EditableCommentBlock>
+
+      {isEditing && (
+        <CommentEditActionButtons
+          onCancel={handleCancel}
+          onSubmit={handleSubmit}
+          isSubmitDisabled={!description.trim()}
+        />
+      )}
+    </>
   );
 }
 
-const Wrapper = styled.div`
+const EditableCommentBlock = styled.div<{ isEditing: boolean }>`
   display: flex;
   flex-direction: column;
   border-radius: ${({ theme }) => theme.radius.large};
-  border: 1px solid ${({ theme }) => theme.neutral.border.default};
+  box-shadow: ${({ isEditing, theme }) =>
+    isEditing
+      ? `0 0 0 1px ${theme.neutral.border.active}`
+      : `0 0 0 1px ${theme.neutral.border.default}`};
+
+  background-color: ${({ theme }) => theme.neutral.surface.strong};
+
   overflow: hidden;
+  transition: border 0.2s ease;
 `;

--- a/frontend/src/features/issue/components/detail/DescriptionBox.tsx
+++ b/frontend/src/features/issue/components/detail/DescriptionBox.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import { useState } from 'react';
 import { useCurrentUser } from '@/features/auth/hooks/useCurrentUser';
 import { type CommentAuthor } from '@/features/issue/types/issue';
+import Divider from '@/shared/components/Divider';
 import DescriptionHeader from '@/features/issue/components/detail/DescriptionHeader';
 import DescriptionBody from '@/features/issue/components/detail/DescriptionBody';
 import CommentInputSection from '@/features/newIssue/components/CommentInputSection';
@@ -43,6 +44,7 @@ export default function DescriptionBox({
           isAuthor={isAuthor}
           onEditClick={() => setIsEditing(true)}
         />
+        <Divider />
         {isEditing ? (
           <CommentInputSection
             value={description}

--- a/frontend/src/features/issue/components/detail/DescriptionBox.tsx
+++ b/frontend/src/features/issue/components/detail/DescriptionBox.tsx
@@ -28,6 +28,8 @@ export default function DescriptionBox({
 
   const isAuthor = currentUser?.nickname === author.nickname;
 
+  const isUnchanged = description.trim() === (content?.trim() ?? '');
+
   const handleSubmit = () => {
     onSubmit(description);
     setIsEditing(false);
@@ -64,7 +66,7 @@ export default function DescriptionBox({
         <CommentEditActionButtons
           onCancel={handleCancel}
           onSubmit={handleSubmit}
-          isSubmitDisabled={!description.trim()}
+          isSubmitDisabled={isUnchanged}
         />
       )}
     </>

--- a/frontend/src/features/issue/components/detail/DescriptionBox.tsx
+++ b/frontend/src/features/issue/components/detail/DescriptionBox.tsx
@@ -12,12 +12,14 @@ export interface DescriptionBoxProps {
   content: string | null;
   author: CommentAuthor;
   createdAt: string;
+  onSubmit: (value: string) => void;
 }
 
 export default function DescriptionBox({
   content,
   author,
   createdAt,
+  onSubmit,
 }: DescriptionBoxProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [description, setDescription] = useState(content || '');
@@ -27,7 +29,7 @@ export default function DescriptionBox({
   const isAuthor = currentUser?.nickname === author.nickname;
 
   const handleSubmit = () => {
-    // TODO: mutation 연결
+    onSubmit(description);
     setIsEditing(false);
   };
 

--- a/frontend/src/features/issue/components/detail/DescriptionHeader.tsx
+++ b/frontend/src/features/issue/components/detail/DescriptionHeader.tsx
@@ -10,12 +10,14 @@ interface DescriptionHeaderProps {
   author: User;
   createdAt: string;
   isAuthor: boolean;
+  onEditClick: () => void;
 }
 
 export default function DescriptionHeader({
   author,
   createdAt,
   isAuthor = false,
+  onEditClick,
 }: DescriptionHeaderProps) {
   const { id, nickname, profileImage } = author;
   return (
@@ -27,16 +29,16 @@ export default function DescriptionHeader({
 
       <RightSection>
         {isAuthor && <AuthorTag>작성자</AuthorTag>}
-        <Button
-          variant="ghost"
-          size="small"
-          icon={<EditIcon />}
-          onClick={() => {
-            /* 편집 로직 */
-          }}
-        >
-          편집
-        </Button>
+        {isAuthor && (
+          <Button
+            variant="ghost"
+            size="small"
+            icon={<EditIcon />}
+            onClick={onEditClick}
+          >
+            편집
+          </Button>
+        )}
 
         <Button
           variant="ghost"

--- a/frontend/src/features/issue/components/detail/DescriptionHeader.tsx
+++ b/frontend/src/features/issue/components/detail/DescriptionHeader.tsx
@@ -60,7 +60,6 @@ const Container = styled.div`
   justify-content: space-between;
   align-items: center;
   padding: 16px 24px;
-  border: 1px solid ${({ theme }) => theme.neutral.surface.default};
 `;
 
 const LeftSection = styled.div`

--- a/frontend/src/features/issue/components/detail/IssueDescription.tsx
+++ b/frontend/src/features/issue/components/detail/IssueDescription.tsx
@@ -3,5 +3,9 @@ import DescriptionBox, {
 } from '@/features/issue/components/detail/DescriptionBox';
 
 export default function IssueDescription(props: DescriptionBoxProps) {
-  return <DescriptionBox {...props} />;
+  const handleSubmit = (description: string) => {
+    // TODO 이슈 description 편집 로직
+  };
+
+  return <DescriptionBox {...props} onSubmit={handleSubmit} />;
 }

--- a/frontend/src/features/issue/hooks/useUpdateComment.ts
+++ b/frontend/src/features/issue/hooks/useUpdateComment.ts
@@ -1,0 +1,15 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import PutComment from '@/features/issue/api/putComment';
+import { type PutCommentParams } from '@/features/issue/types/comment';
+
+export function useUpdateComment(issueId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ commentId, content }: Omit<PutCommentParams, 'issueId'>) =>
+      PutComment({ issueId, commentId, content }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['issueComments', issueId] });
+    },
+  });
+}

--- a/frontend/src/features/issue/types/comment.ts
+++ b/frontend/src/features/issue/types/comment.ts
@@ -1,0 +1,5 @@
+export interface PutCommentParams {
+  issueId: number;
+  commentId: number;
+  content: string;
+}

--- a/frontend/src/features/newIssue/components/CommentInputSection.tsx
+++ b/frontend/src/features/newIssue/components/CommentInputSection.tsx
@@ -10,6 +10,9 @@ const DEFAULT_HEIGTH = 80;
 interface CommentInputSectionProps {
   value: string;
   onChange: (value: string | ((prev: string) => string)) => void;
+  isFocused: boolean;
+  onFocus: () => void;
+  onBlur: () => void;
   initialHeight?: number;
   maxHeight?: number;
 }
@@ -17,10 +20,12 @@ interface CommentInputSectionProps {
 export default function CommentInputSection({
   value,
   onChange,
+  isFocused,
+  onFocus,
+  onBlur,
   initialHeight = DEFAULT_HEIGTH,
   maxHeight,
 }: CommentInputSectionProps) {
-  const [isFocused, setIsFocused] = useState(false);
   const [showCharCount, setShowCharCount] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -84,7 +89,7 @@ export default function CommentInputSection({
   }, [value]);
 
   return (
-    <EditorContainer isFocused={isFocused}>
+    <EditorContainer>
       <LabelAbove isFloating={isFocused || !!value}>
         코멘트를 입력하세요
       </LabelAbove>
@@ -92,8 +97,8 @@ export default function CommentInputSection({
         ref={textareaRef}
         value={value}
         onChange={e => onChange(e.target.value)}
-        onFocus={() => setIsFocused(true)}
-        onBlur={() => setIsFocused(false)}
+        onFocus={onFocus}
+        onBlur={onBlur}
         initialHeight={initialHeight}
         maxHeight={maxHeight}
       />
@@ -109,21 +114,13 @@ export default function CommentInputSection({
   );
 }
 
-const EditorContainer = styled.section<{ isFocused: boolean }>`
+const EditorContainer = styled.section`
   position: relative;
   height: auto;
   flex: 1;
   display: flex;
   flex-direction: column;
   gap: 12px;
-  border-radius: ${({ theme }) => theme.radius.medium};
-  overflow: hidden;
-
-  background-color: ${({ isFocused, theme }) =>
-    isFocused ? theme.neutral.surface.default : theme.neutral.surface.bold};
-
-  box-shadow: ${({ isFocused, theme }) =>
-    isFocused ? `0 0 0 1px ${theme.neutral.border.active}` : 'none'};
 `;
 
 const ContentTextarea = styled.textarea<{

--- a/frontend/src/features/newIssue/components/NewIssueForm.tsx
+++ b/frontend/src/features/newIssue/components/NewIssueForm.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { useState } from 'react';
 import CommentInputSection from '@/features/newIssue/components/CommentInputSection';
 import TitleInput from '@/features/newIssue/components/TitleInput';
 
@@ -16,14 +17,22 @@ export default function NewIssueForm({
   onTitleChange,
   onContentChange,
 }: NewIssueFormProps) {
+  const [isFocused, setIsFocused] = useState(false);
+
   return (
     <FormSection>
       <TitleInput value={title} onChange={onTitleChange} label="제목" />
-      <CommentInputSection
-        value={content}
-        onChange={onContentChange}
-        initialHeight={448}
-      />
+
+      <CommentInputWrapper isFocused={isFocused}>
+        <CommentInputSection
+          value={content}
+          onChange={onContentChange}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setIsFocused(false)}
+          isFocused={isFocused}
+          initialHeight={448}
+        />
+      </CommentInputWrapper>
     </FormSection>
   );
 }
@@ -33,4 +42,20 @@ const FormSection = styled.section`
   display: flex;
   flex-direction: column;
   gap: 16px;
+`;
+
+const CommentInputWrapper = styled.section<{ isFocused: boolean }>`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  border-radius: ${({ theme }) => theme.radius.medium};
+  overflow: hidden;
+
+  background-color: ${({ isFocused, theme }) =>
+    isFocused ? theme.neutral.surface.default : theme.neutral.surface.bold};
+
+  box-shadow: ${({ isFocused, theme }) =>
+    isFocused ? `0 0 0 1px ${theme.neutral.border.active}` : 'none'};
 `;

--- a/frontend/src/shared/constants/api.ts
+++ b/frontend/src/shared/constants/api.ts
@@ -9,6 +9,8 @@ export const API = {
   ISSUE_LABELS: (id: number) => `${API_BASE_URL}/issues/${id}/labels`,
   ISSUE_ASSIGNEES: (id: number) => `${API_BASE_URL}/issues/${id}/assignees`,
   ISSUE_MILESTONE: (id: number) => `${API_BASE_URL}/issues/${id}/milestone`,
+  ISSUE_COMMENT: (issueId: number, commentId: number) =>
+    `${API_BASE_URL}/issues/${issueId}/comments/${commentId}`,
 
   ISSUE_STATE: (id: number) => `${API_BASE_URL}/issues/${id}/state`,
 


### PR DESCRIPTION
## 📌 PR 제목

[Feature] 댓글 수정 기능 및 입력 영역 리팩토링

## ✅ 작업 요약

- [x] 댓글 수정 기능 구현  
  - 기존 입력 UI를 재사용하여 수정 모드에서도 일관된 입력 경험 제공
  - `onSubmit` props를 통해 수정 완료 동작 분리 및 재사용성 확보
  - 수정 완료 버튼은 내용이 변경된 경우에만 활성화되도록 처리

- [x] 입력 영역 리팩토링  
  - `CommentInputSection`에서 포커스 상태 및 스타일링 로직 제거
  - 해당 로직은 부모에서 처리하도록 분리하여 유연한 UI 구성이 가능하도록 개선

- [x] UI 분기 처리 및 스타일 개선  
  - 편집 모드일 때 `Edit / Cancel` 버튼을 별도 컴포넌트로 분리
  - 기존 헤더 영역의 `border-bottom` 제거하고 `Divider` 컴포넌트로 시각적 구분 처리

## ✅ 테스트 확인

- [x] 댓글 수정 시 기존 내용이 자동 입력됨
- [x] 내용이 변경된 경우에만 "편집 완료" 버튼 활성화됨
- [x] 수정 완료 시 수정된 내용이 정상 반영됨
- [x] `isEditing` 상태에 따라 UI가 정확히 분기되어 동작함
- [x] `Divider`가 헤더 하단에 정상적으로 적용됨
- [x] CI 정상 통과 확인

## 🧠 회고/고민

### 1. 입력 영역의 재사용성과 유연성 확보

#### 고민의 배경
- 댓글과 이슈 설명 모두 동일한 입력 UI를 사용하는 구조였으나, 포커스 상태와 스타일링이 `CommentInputSection` 내부에 존재함
- 입력 영역은 단순히 입력값을 보여주는 역할에 집중하고, 상호작용 및 상태 관리는 외부에서 처리하는 방식이 더 유연하다고 판단

#### 결정 및 처리
- 입력 UI에서 포커스 상태 및 스타일링 관련 상태 제거
- 부모 컴포넌트(`DescriptionBox`)에서 해당 상태를 관리하여, 재사용 컴포넌트의 책임을 명확히 분리
- 이로 인해 다른 위치에서도 같은 컴포넌트를 다양한 방식으로 조합 가능하게 되었음

### 2. 편집 모드 UI 구성 시 구조의 명확성

#### 고민의 배경
- 편집 모드일 때 편집 완료 및 취소 버튼의 위치와 스타일을 통일성 있게 구성해야 했음
- 입력 창과 버튼 영역이 명확히 구분되지 않으면 UI가 어수선해지는 문제가 있었음

#### 결정 및 처리
- 편집 모드일 경우 하단에만 별도의 버튼 영역이 나타나도록 구성
- 버튼을 별도의 컴포넌트로 분리하여 UI 책임 분리 및 재사용 가능성 확보
- 기존 헤더의 border 대신 Divider 컴포넌트를 사용하여 시각적 일관성 유지


  closes #166 #161 

---
## 추후 작업 예정
- 이슈 설명란 수정 기능은 추후 구현 예정  
  related #167 

