### PR TITLE
[Feature] 이슈 메타정보(제목,내용, 라벨, 담당자, 마일스톤) 수정 기능 구현 및 사이드바 리팩토링

### DIFF
--- a/frontend/src/features/issue/api/patchIssueContent.ts
+++ b/frontend/src/features/issue/api/patchIssueContent.ts
@@ -1,0 +1,31 @@
+import { API } from '@/shared/constants/api';
+import fetchWithAuth from '@/shared/utils/fetchWithAuth';
+import { type PatchIssueContentParams } from '@/features/issue/types/issue';
+
+export async function patchIssueContent({
+  issueId,
+  content,
+}: PatchIssueContentParams): Promise<void> {
+  const res = await fetchWithAuth(API.ISSUE_CONTENT(issueId), {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  });
+
+  const statusCodeHandler: Record<number, () => Promise<void>> = {
+    204: async () => {},
+    401: () => {
+      window.location.href = '/login';
+      return Promise.reject(new Error('로그인이 필요합니다'));
+    },
+    404: () => Promise.reject(new Error('요청한 이슈가 존재하지 않습니다')),
+    500: () => Promise.reject(new Error('서버 오류가 발생했습니다')),
+  };
+
+  const defaultHandler = () =>
+    Promise.reject(
+      new Error(`예상치 못한 오류가 발생했습니다 (status: ${res.status})`),
+    );
+
+  return (statusCodeHandler[res.status] ?? defaultHandler)();
+}

--- a/frontend/src/features/issue/api/patchIssueMilestone.ts
+++ b/frontend/src/features/issue/api/patchIssueMilestone.ts
@@ -1,0 +1,30 @@
+import { API } from '@/shared/constants/api';
+import fetchWithAuth from '@/shared/utils/fetchWithAuth';
+
+export const patchIssueMilestone = async (
+  issueId: number,
+  milestoneId: number,
+) => {
+  const response = await fetchWithAuth(API.ISSUE_MILESTONE(issueId), {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id: milestoneId }),
+  });
+
+  const statusCodeHandler: Record<number, () => Promise<void>> = {
+    204: () => Promise.resolve(),
+    401: () => {
+      window.location.href = '/login';
+      return Promise.reject(new Error('로그인이 필요합니다'));
+    },
+    404: () => Promise.reject(new Error('요청 경로가 잘못되었습니다')),
+    500: () => Promise.reject(new Error('서버 오류가 발생했습니다')),
+  };
+
+  const defaultHandler = () =>
+    Promise.reject(
+      new Error(`예상치 못한 오류가 발생했습니다 (status: ${response.status})`),
+    );
+
+  return (statusCodeHandler[response.status] ?? defaultHandler)();
+};

--- a/frontend/src/features/issue/api/patchIssueMilestone.ts
+++ b/frontend/src/features/issue/api/patchIssueMilestone.ts
@@ -3,7 +3,7 @@ import fetchWithAuth from '@/shared/utils/fetchWithAuth';
 
 export const patchIssueMilestone = async (
   issueId: number,
-  milestoneId: number,
+  milestoneId: number | null,
 ) => {
   const response = await fetchWithAuth(API.ISSUE_MILESTONE(issueId), {
     method: 'PATCH',

--- a/frontend/src/features/issue/api/patchIssueTitle.ts
+++ b/frontend/src/features/issue/api/patchIssueTitle.ts
@@ -1,0 +1,37 @@
+import { API } from '@/shared/constants/api';
+import fetchWithAuth from '@/shared/utils/fetchWithAuth';
+
+interface Params {
+  issueId: number;
+  title: string;
+}
+
+export async function patchIssueTitle({
+  issueId,
+  title,
+}: Params): Promise<void> {
+  const response = await fetchWithAuth(API.ISSUE_TITLE(issueId), {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ title }),
+  });
+
+  const statusCodeHandler: Record<number, () => Promise<void>> = {
+    204: () => Promise.resolve(),
+    401: () => {
+      window.location.href = '/login';
+      return Promise.reject(new Error('로그인이 필요합니다'));
+    },
+    404: () => Promise.reject(new Error('요청 경로가 잘못되었습니다')),
+    500: () => Promise.reject(new Error('서버 오류가 발생했습니다')),
+  };
+
+  const defaultHandler = () =>
+    Promise.reject(
+      new Error(`예상치 못한 오류가 발생했습니다 (status: ${response.status})`),
+    );
+
+  return (statusCodeHandler[response.status] ?? defaultHandler)();
+}

--- a/frontend/src/features/issue/api/putIssueAssignees.ts
+++ b/frontend/src/features/issue/api/putIssueAssignees.ts
@@ -1,0 +1,30 @@
+import { API } from '@/shared/constants/api';
+import fetchWithAuth from '@/shared/utils/fetchWithAuth';
+
+export const putIssueAssignees = async (
+  issueId: number,
+  assigneeIds: number[],
+) => {
+  const response = await fetchWithAuth(API.ISSUE_ASSIGNEES(issueId), {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ assignees: assigneeIds }),
+  });
+
+  const statusCodeHandler: Record<number, () => Promise<void>> = {
+    204: () => Promise.resolve(),
+    401: () => {
+      window.location.href = '/login';
+      return Promise.reject(new Error('로그인이 필요합니다'));
+    },
+    404: () => Promise.reject(new Error('요청 경로가 잘못되었습니다')),
+    500: () => Promise.reject(new Error('서버 오류가 발생했습니다')),
+  };
+
+  const defaultHandler = () =>
+    Promise.reject(
+      new Error(`예상치 못한 오류가 발생했습니다 (status: ${response.status})`),
+    );
+
+  return (statusCodeHandler[response.status] ?? defaultHandler)();
+};

--- a/frontend/src/features/issue/api/putIssueLabels.ts
+++ b/frontend/src/features/issue/api/putIssueLabels.ts
@@ -1,0 +1,27 @@
+import { API } from '@/shared/constants/api';
+import fetchWithAuth from '@/shared/utils/fetchWithAuth';
+
+export const putIssueLabels = async (issueId: number, labelIds: number[]) => {
+  const response = await fetchWithAuth(API.ISSUE_LABELS(issueId), {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ labels: labelIds }),
+  });
+
+  const statusCodeHandler: Record<number, () => Promise<void>> = {
+    204: () => Promise.resolve(),
+    401: () => {
+      window.location.href = '/login';
+      return Promise.reject(new Error('로그인이 필요합니다'));
+    },
+    404: () => Promise.reject(new Error('요청 경로가 잘못되었습니다')),
+    500: () => Promise.reject(new Error('서버 오류가 발생했습니다')),
+  };
+
+  const defaultHandler = () =>
+    Promise.reject(
+      new Error(`예상치 못한 오류가 발생했습니다 (status: ${response.status})`),
+    );
+
+  return (statusCodeHandler[response.status] ?? defaultHandler)();
+};

--- a/frontend/src/features/issue/components/detail/IssueDescription.tsx
+++ b/frontend/src/features/issue/components/detail/IssueDescription.tsx
@@ -1,3 +1,5 @@
+import { useParams } from 'react-router-dom';
+import { usePatchIssueContent } from '@/features/issue/hooks/usePatchIssueContent';
 import DescriptionBox from '@/features/issue/components/detail/DescriptionBox';
 import { type CommentAuthor } from '@/features/issue/types/issue';
 
@@ -7,10 +9,25 @@ interface IssueDescriptionProps {
   createdAt: string;
 }
 
-export default function IssueDescription(props: IssueDescriptionProps) {
+export default function IssueDescription({
+  content,
+  author,
+  createdAt,
+}: IssueDescriptionProps) {
+  const { id } = useParams();
+  const issueId = Number(id);
+  const { mutate } = usePatchIssueContent(issueId);
+
   const handleSubmit = (description: string) => {
-    // TODO 이슈 description 편집 로직
+    mutate({ issueId, content: description });
   };
 
-  return <DescriptionBox {...props} onSubmit={handleSubmit} />;
+  return (
+    <DescriptionBox
+      content={content}
+      author={author}
+      createdAt={createdAt}
+      onSubmit={handleSubmit}
+    />
+  );
 }

--- a/frontend/src/features/issue/components/detail/IssueDescription.tsx
+++ b/frontend/src/features/issue/components/detail/IssueDescription.tsx
@@ -1,8 +1,13 @@
-import DescriptionBox, {
-  type DescriptionBoxProps,
-} from '@/features/issue/components/detail/DescriptionBox';
+import DescriptionBox from '@/features/issue/components/detail/DescriptionBox';
+import { type CommentAuthor } from '@/features/issue/types/issue';
 
-export default function IssueDescription(props: DescriptionBoxProps) {
+interface IssueDescriptionProps {
+  content: string | null;
+  author: CommentAuthor;
+  createdAt: string;
+}
+
+export default function IssueDescription(props: IssueDescriptionProps) {
   const handleSubmit = (description: string) => {
     // TODO 이슈 description 편집 로직
   };

--- a/frontend/src/features/issue/components/detail/IssueDetailSidebar.tsx
+++ b/frontend/src/features/issue/components/detail/IssueDetailSidebar.tsx
@@ -9,24 +9,42 @@ interface Props {
 }
 
 export default function IssueDetailSidebar({ issueId }: Props) {
-  const { issueLabels } = useIssueLabels(issueId);
-  const { issueAssignees } = useIssueAssignees(issueId);
-  const { issueMilestone } = useIssueMilestone(issueId);
+  const {
+    issueLabels,
+    isLoading: isLabelsLoading,
+    isError: isLabelsError,
+  } = useIssueLabels(issueId);
+
+  const {
+    issueAssignees,
+    isLoading: isAssigneesLoading,
+    isError: isAssigneesError,
+  } = useIssueAssignees(issueId);
+
+  const {
+    issueMilestone,
+    isLoading: isMilestoneLoading,
+    isError: isMilestoneError,
+  } = useIssueMilestone(issueId);
+
+  const isLoading = isLabelsLoading || isAssigneesLoading || isMilestoneLoading;
+  const isError = isLabelsError || isAssigneesError || isMilestoneError;
+
+  if (isLoading) return null;
+  if (isError) return <div>데이터를 불러오는 데 실패했습니다.</div>;
 
   const selectedAssigneeIds = issueAssignees.map(assignee => assignee.id);
   const selectedLabelIds = issueLabels.map(label => label.id);
   const selectedMilestoneId = issueMilestone?.id ?? null;
 
-  // TODO 로딩, 에러 처리 분기
-
   return (
     <IssueSidebar
-      selectedAssigneeIds={selectedAssigneeIds}
-      onToggleAssignee={() => {}}
-      selectedLabelIds={selectedLabelIds}
-      onToggleLabel={() => {}}
-      selectedMilestoneId={selectedMilestoneId}
-      onSelectMilestone={() => {}}
+      initialAssigneeIds={selectedAssigneeIds}
+      onSaveAssignee={() => {}}
+      initialLabelIds={selectedLabelIds}
+      onSaveLabel={() => {}}
+      initialMilestoneId={selectedMilestoneId}
+      onSaveMilestone={() => {}}
     />
   );
 }

--- a/frontend/src/features/issue/components/detail/IssueDetailSidebar.tsx
+++ b/frontend/src/features/issue/components/detail/IssueDetailSidebar.tsx
@@ -1,0 +1,32 @@
+import useIssueLabels from '@/features/issue/hooks/useIssueLabels';
+import useIssueAssignees from '@/features/issue/hooks/useIssueAssignees';
+import useIssueMilestone from '@/features/issue/hooks/useIssueMilestone';
+
+import IssueSidebar from '@/shared/components/sidebar';
+
+interface Props {
+  issueId: number;
+}
+
+export default function IssueDetailSidebar({ issueId }: Props) {
+  const { issueLabels } = useIssueLabels(issueId);
+  const { issueAssignees } = useIssueAssignees(issueId);
+  const { issueMilestone } = useIssueMilestone(issueId);
+
+  const selectedAssigneeIds = issueAssignees.map(assignee => assignee.id);
+  const selectedLabelIds = issueLabels.map(label => label.id);
+  const selectedMilestoneId = issueMilestone?.id ?? null;
+
+  // TODO 로딩, 에러 처리 분기
+
+  return (
+    <IssueSidebar
+      selectedAssigneeIds={selectedAssigneeIds}
+      onToggleAssignee={() => {}}
+      selectedLabelIds={selectedLabelIds}
+      onToggleLabel={() => {}}
+      selectedMilestoneId={selectedMilestoneId}
+      onSelectMilestone={() => {}}
+    />
+  );
+}

--- a/frontend/src/features/issue/components/detail/IssueDetailSidebar.tsx
+++ b/frontend/src/features/issue/components/detail/IssueDetailSidebar.tsx
@@ -2,6 +2,10 @@ import useIssueLabels from '@/features/issue/hooks/useIssueLabels';
 import useIssueAssignees from '@/features/issue/hooks/useIssueAssignees';
 import useIssueMilestone from '@/features/issue/hooks/useIssueMilestone';
 
+import { usePutIssueLabels } from '@/features/issue/hooks/usePutIssueLabels';
+import { usePutIssueAssignees } from '@/features/issue/hooks/usePutIssueAssignees';
+import { usePatchIssueMilestone } from '@/features/issue/hooks/usePatchIssueMilestone';
+
 import IssueSidebar from '@/shared/components/sidebar';
 
 interface Props {
@@ -27,6 +31,10 @@ export default function IssueDetailSidebar({ issueId }: Props) {
     isError: isMilestoneError,
   } = useIssueMilestone(issueId);
 
+  const { mutate: mutateLabel } = usePutIssueLabels(issueId);
+  const { mutate: mutateAssignee } = usePutIssueAssignees(issueId);
+  const { mutate: mutateMilestone } = usePatchIssueMilestone(issueId);
+
   const isLoading = isLabelsLoading || isAssigneesLoading || isMilestoneLoading;
   const isError = isLabelsError || isAssigneesError || isMilestoneError;
 
@@ -40,11 +48,11 @@ export default function IssueDetailSidebar({ issueId }: Props) {
   return (
     <IssueSidebar
       initialAssigneeIds={selectedAssigneeIds}
-      onSaveAssignee={() => {}}
+      onSaveAssignee={mutateAssignee}
       initialLabelIds={selectedLabelIds}
-      onSaveLabel={() => {}}
+      onSaveLabel={mutateLabel}
       initialMilestoneId={selectedMilestoneId}
-      onSaveMilestone={() => {}}
+      onSaveMilestone={mutateMilestone}
     />
   );
 }

--- a/frontend/src/features/issue/components/detail/IssueDetailSidebar.tsx
+++ b/frontend/src/features/issue/components/detail/IssueDetailSidebar.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import useIssueLabels from '@/features/issue/hooks/useIssueLabels';
 import useIssueAssignees from '@/features/issue/hooks/useIssueAssignees';
 import useIssueMilestone from '@/features/issue/hooks/useIssueMilestone';
@@ -38,7 +39,6 @@ export default function IssueDetailSidebar({ issueId }: Props) {
   const isLoading = isLabelsLoading || isAssigneesLoading || isMilestoneLoading;
   const isError = isLabelsError || isAssigneesError || isMilestoneError;
 
-  if (isLoading) return null;
   if (isError) return <div>데이터를 불러오는 데 실패했습니다.</div>;
 
   const selectedAssigneeIds = issueAssignees.map(assignee => assignee.id);
@@ -46,13 +46,25 @@ export default function IssueDetailSidebar({ issueId }: Props) {
   const selectedMilestoneId = issueMilestone?.id ?? null;
 
   return (
-    <IssueSidebar
-      initialAssigneeIds={selectedAssigneeIds}
-      onSaveAssignee={mutateAssignee}
-      initialLabelIds={selectedLabelIds}
-      onSaveLabel={mutateLabel}
-      initialMilestoneId={selectedMilestoneId}
-      onSaveMilestone={mutateMilestone}
-    />
+    <SidebarWrapper visible={!isLoading}>
+      {!isLoading && (
+        <IssueSidebar
+          initialAssigneeIds={selectedAssigneeIds}
+          onSaveAssignee={mutateAssignee}
+          initialLabelIds={selectedLabelIds}
+          onSaveLabel={mutateLabel}
+          initialMilestoneId={selectedMilestoneId}
+          onSaveMilestone={mutateMilestone}
+        />
+      )}
+    </SidebarWrapper>
   );
 }
+
+const SidebarWrapper = styled.div<{ visible: boolean }>`
+  min-height: 300px;
+  min-width: 288px;
+  flex-shrink: 0;
+  opacity: ${({ visible }) => (visible ? 1 : 0)};
+  transition: opacity 0.3s ease-in-out;
+`;

--- a/frontend/src/features/issue/components/detail/IssueHeader.tsx
+++ b/frontend/src/features/issue/components/detail/IssueHeader.tsx
@@ -1,9 +1,6 @@
 import styled from '@emotion/styled';
-import { formatCreatedMessage } from '@/features/issue/utils';
-import ClosedIcon from '@/assets/icons/archive.svg?react';
-import EditIcon from '@/assets/icons/edit.svg?react';
-import AlertCircleIcon from '@/assets/icons/alertCircle.svg?react';
-import Button from '@/shared/components/Button';
+import IssueMeta from './IssueMeta';
+import IssueHeaderActions from './IssueHeaderActions';
 
 interface IssueHeaderProps {
   isClosed: boolean;
@@ -35,40 +32,19 @@ export default function IssueHeader({
         <Title>
           {title} <IssueNumber>#{issueNumber}</IssueNumber>
         </Title>
-        <IssueMetaWrapper>
-          <IsClosedButton isClosed={isClosed}>
-            <AlertCircleIcon />
-            <StateBadge>{isClosed ? '닫힌 이슈' : '열린 이슈'}</StateBadge>
-          </IsClosedButton>
-          <MetaInfo>
-            {formatCreatedMessage({
-              createdAt,
-              author: author.nickname,
-              isClosed,
-            })}
-          </MetaInfo>
-          <CommentCount>코멘트 {commentCount}개</CommentCount>
-        </IssueMetaWrapper>
+
+        <IssueMeta
+          isClosed={isClosed}
+          createdAt={createdAt}
+          authorName={author.nickname}
+          commentCount={commentCount}
+        />
       </LeftSection>
       <RightSection>
-        <Button
-          variant="outline"
-          size="small"
-          icon={<EditIcon />}
-          onClick={() => {
-            /* 편집 로직 */
-          }}
-        >
-          제목 편집
-        </Button>
-        <Button
-          variant="outline"
-          size="small"
-          icon={<ClosedIcon />}
-          onClick={onToggleIssueState}
-        >
-          {isClosed ? '이슈 열기' : '이슈 닫기'}
-        </Button>
+        <IssueHeaderActions
+          isClosed={isClosed}
+          onToggleIssueState={onToggleIssueState}
+        />
       </RightSection>
     </HeaderWrapper>
   );
@@ -83,13 +59,6 @@ const LeftSection = styled.div`
   display: flex;
   flex-direction: column;
   gap: 16px;
-`;
-
-const IssueMetaWrapper = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
 `;
 
 const RightSection = styled.div`
@@ -110,40 +79,4 @@ const Title = styled.h1`
 
 const IssueNumber = styled.span`
   color: ${({ theme }) => theme.neutral.text.weak};
-`;
-
-const MetaInfo = styled.span`
-  color: ${({ theme }) => theme.neutral.text.weak};
-  ${({ theme }) => theme.typography.displayMedium16};
-`;
-
-const CommentCount = styled.span`
-  margin-left: 24px;
-  color: ${({ theme }) => theme.neutral.text.weak};
-  ${({ theme }) => theme.typography.displayMedium16};
-`;
-
-const IsClosedButton = styled.button<{ isClosed: boolean }>`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: 8px 16px;
-  background-color: ${({ theme, isClosed }) =>
-    isClosed ? theme.palette.navy : theme.palette.blue};
-
-  border-radius: ${({ theme }) => theme.radius.large};
-  color: ${({ theme }) => theme.brand.text.default};
-
-  cursor: pointer;
-  transition: all 0.2s ease;
-
-  &:hover {
-    opacity: 0.8;
-  }
-`;
-
-const StateBadge = styled.span`
-  padding: 0 4px;
-  color: ${({ theme }) => theme.brand.text.default};
-  ${({ theme }) => theme.typography.displayMedium12};
 `;

--- a/frontend/src/features/issue/components/detail/IssueHeader.tsx
+++ b/frontend/src/features/issue/components/detail/IssueHeader.tsx
@@ -1,6 +1,9 @@
+import { useState } from 'react';
 import styled from '@emotion/styled';
+import usePatchIssueTitle from '@/features/issue/hooks/usePatchIssueTitle';
 import IssueMeta from './IssueMeta';
 import IssueHeaderActions from './IssueHeaderActions';
+import TextInput from '@/shared/components/TextInput';
 
 interface IssueHeaderProps {
   isClosed: boolean;
@@ -16,7 +19,6 @@ interface IssueHeaderProps {
   onToggleIssueState: () => void;
 }
 
-//TODO 편집 기능, 이슈 열림 토글 기능 추가시 prop도 추가
 export default function IssueHeader({
   isClosed,
   issueNumber,
@@ -26,12 +28,37 @@ export default function IssueHeader({
   commentCount,
   onToggleIssueState,
 }: IssueHeaderProps) {
+  const { mutate: patchTitle } = usePatchIssueTitle(issueNumber);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editedTitle, setEditedTitle] = useState(title);
+
+  const isSubmitDisabled = editedTitle.trim() === title.trim();
+
+  const handleSubmitEdit = () => {
+    patchTitle(editedTitle);
+    setIsEditing(false);
+  };
+
+  const handleCancelEdit = () => {
+    setEditedTitle(title);
+    setIsEditing(false);
+  };
+
   return (
     <HeaderWrapper>
       <LeftSection>
-        <Title>
-          {title} <IssueNumber>#{issueNumber}</IssueNumber>
-        </Title>
+        {isEditing ? (
+          <TextInput
+            label="제목"
+            value={editedTitle}
+            onChange={e => setEditedTitle(e.target.value)}
+            placeholder="이슈의 제목을 입력해주세요"
+          />
+        ) : (
+          <Title>
+            {title} <IssueNumber>#{issueNumber}</IssueNumber>
+          </Title>
+        )}
 
         <IssueMeta
           isClosed={isClosed}
@@ -42,8 +69,13 @@ export default function IssueHeader({
       </LeftSection>
       <RightSection>
         <IssueHeaderActions
+          isEditing={isEditing}
+          onEditStart={() => setIsEditing(true)}
+          onEditCancel={handleCancelEdit}
+          onEditSubmit={handleSubmitEdit}
           isClosed={isClosed}
           onToggleIssueState={onToggleIssueState}
+          isSubmitDisabled={isSubmitDisabled}
         />
       </RightSection>
     </HeaderWrapper>
@@ -53,11 +85,13 @@ export default function IssueHeader({
 const HeaderWrapper = styled.div`
   display: flex;
   justify-content: space-between;
+  gap: 16px;
 `;
 
 const LeftSection = styled.div`
   display: flex;
   flex-direction: column;
+  flex: 1;
   gap: 16px;
 `;
 

--- a/frontend/src/features/issue/components/detail/IssueHeader.tsx
+++ b/frontend/src/features/issue/components/detail/IssueHeader.tsx
@@ -1,13 +1,14 @@
 import { useState } from 'react';
 import styled from '@emotion/styled';
 import usePatchIssueTitle from '@/features/issue/hooks/usePatchIssueTitle';
+import usePatchIssueState from '@/features/issue/hooks/usePatchIssueState';
 import IssueMeta from './IssueMeta';
 import IssueHeaderActions from './IssueHeaderActions';
 import TextInput from '@/shared/components/TextInput';
 
 interface IssueHeaderProps {
   isClosed: boolean;
-  issueNumber: number;
+  issueId: number;
   title: string;
   author: {
     id: number;
@@ -16,23 +17,29 @@ interface IssueHeaderProps {
   };
   createdAt: string;
   commentCount: number;
-  onToggleIssueState: () => void;
 }
 
 export default function IssueHeader({
   isClosed,
-  issueNumber,
+  issueId,
   title,
   author,
   createdAt,
   commentCount,
-  onToggleIssueState,
 }: IssueHeaderProps) {
-  const { mutate: patchTitle } = usePatchIssueTitle(issueNumber);
+  const { mutate: patchTitle } = usePatchIssueTitle(issueId);
   const [isEditing, setIsEditing] = useState(false);
   const [editedTitle, setEditedTitle] = useState(title);
 
   const isSubmitDisabled = editedTitle.trim() === title.trim();
+
+  const { mutate: toggleIssueState, isPending: isToggleLoading } =
+    usePatchIssueState(issueId);
+
+  const handleToggle = () => {
+    if (isToggleLoading) return;
+    toggleIssueState({ issueId, targetClosed: !isClosed });
+  };
 
   const handleSubmitEdit = () => {
     patchTitle(editedTitle);
@@ -57,7 +64,7 @@ export default function IssueHeader({
         ) : (
           <Title>
             <TitleText>{title}</TitleText>
-            <IssueNumber>#{issueNumber}</IssueNumber>
+            <IssueNumber>#{issueId}</IssueNumber>
           </Title>
         )}
 
@@ -67,7 +74,7 @@ export default function IssueHeader({
           onEditCancel={handleCancelEdit}
           onEditSubmit={handleSubmitEdit}
           isClosed={isClosed}
-          onToggleIssueState={onToggleIssueState}
+          onToggleIssueState={handleToggle}
           isSubmitDisabled={isSubmitDisabled}
         />
       </TopRow>

--- a/frontend/src/features/issue/components/detail/IssueHeader.tsx
+++ b/frontend/src/features/issue/components/detail/IssueHeader.tsx
@@ -46,7 +46,7 @@ export default function IssueHeader({
 
   return (
     <HeaderWrapper>
-      <LeftSection>
+      <TopRow>
         {isEditing ? (
           <TextInput
             label="제목"
@@ -56,18 +56,11 @@ export default function IssueHeader({
           />
         ) : (
           <Title>
-            {title} <IssueNumber>#{issueNumber}</IssueNumber>
+            <TitleText>{title}</TitleText>
+            <IssueNumber>#{issueNumber}</IssueNumber>
           </Title>
         )}
 
-        <IssueMeta
-          isClosed={isClosed}
-          createdAt={createdAt}
-          authorName={author.nickname}
-          commentCount={commentCount}
-        />
-      </LeftSection>
-      <RightSection>
         <IssueHeaderActions
           isEditing={isEditing}
           onEditStart={() => setIsEditing(true)}
@@ -77,40 +70,50 @@ export default function IssueHeader({
           onToggleIssueState={onToggleIssueState}
           isSubmitDisabled={isSubmitDisabled}
         />
-      </RightSection>
+      </TopRow>
+
+      <IssueMeta
+        isClosed={isClosed}
+        createdAt={createdAt}
+        authorName={author.nickname}
+        commentCount={commentCount}
+      />
     </HeaderWrapper>
   );
 }
 
 const HeaderWrapper = styled.div`
   display: flex;
-  justify-content: space-between;
-  gap: 16px;
-`;
-
-const LeftSection = styled.div`
-  display: flex;
   flex-direction: column;
-  flex: 1;
   gap: 16px;
 `;
 
-const RightSection = styled.div`
+const TopRow = styled.div`
   display: flex;
+  justify-content: space-between;
   align-items: center;
   gap: 16px;
-  height: 48px;
+  min-height: 48px;
 `;
 
 const Title = styled.h1`
-  display: flex;
-  align-items: flex-start;
+  display: inline;
+  flex-wrap: wrap;
   gap: 8px;
 
   color: ${({ theme }) => theme.neutral.text.strong};
   ${({ theme }) => theme.typography.displayBold32};
 `;
 
+const TitleText = styled.span`
+  flex: 1;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  margin-right: 8px;
+`;
+
 const IssueNumber = styled.span`
+  align-self: flex-start;
   color: ${({ theme }) => theme.neutral.text.weak};
+  white-space: nowrap;
 `;

--- a/frontend/src/features/issue/components/detail/IssueHeaderActions.tsx
+++ b/frontend/src/features/issue/components/detail/IssueHeaderActions.tsx
@@ -1,36 +1,70 @@
 import Button from '@/shared/components/Button';
 import EditIcon from '@/assets/icons/edit.svg?react';
+import CheckIcon from '@/assets/icons/chevronDown.svg?react';
+import XIcon from '@/assets/icons/xSquare.svg?react';
 import ClosedIcon from '@/assets/icons/archive.svg?react';
 
 interface Props {
+  isEditing: boolean;
+  onEditStart: () => void;
+  onEditCancel: () => void;
+  onEditSubmit: () => void;
   isClosed: boolean;
   onToggleIssueState: () => void;
+  isSubmitDisabled: boolean;
 }
 
 export default function IssueHeaderActions({
+  isEditing,
+  onEditStart,
+  onEditCancel,
+  onEditSubmit,
   isClosed,
   onToggleIssueState,
+  isSubmitDisabled,
 }: Props) {
   return (
     <>
-      <Button
-        variant="outline"
-        size="small"
-        icon={<EditIcon />}
-        onClick={() => {
-          // TODO 편집로직
-        }}
-      >
-        제목 편집
-      </Button>
-      <Button
-        variant="outline"
-        size="small"
-        icon={<ClosedIcon />}
-        onClick={onToggleIssueState}
-      >
-        {isClosed ? '이슈 열기' : '이슈 닫기'}
-      </Button>
+      {isEditing ? (
+        <>
+          <Button
+            variant="outline"
+            size="small"
+            icon={<XIcon />}
+            onClick={onEditCancel}
+          >
+            편집 취소
+          </Button>
+          <Button
+            variant="outline"
+            size="small"
+            icon={<CheckIcon />}
+            onClick={onEditSubmit}
+            disabled={isSubmitDisabled}
+          >
+            편집 완료
+          </Button>
+        </>
+      ) : (
+        <>
+          <Button
+            variant="outline"
+            size="small"
+            icon={<EditIcon />}
+            onClick={onEditStart}
+          >
+            제목 편집
+          </Button>
+          <Button
+            variant="outline"
+            size="small"
+            icon={<ClosedIcon />}
+            onClick={onToggleIssueState}
+          >
+            {isClosed ? '이슈 열기' : '이슈 닫기'}
+          </Button>
+        </>
+      )}
     </>
   );
 }

--- a/frontend/src/features/issue/components/detail/IssueHeaderActions.tsx
+++ b/frontend/src/features/issue/components/detail/IssueHeaderActions.tsx
@@ -1,0 +1,36 @@
+import Button from '@/shared/components/Button';
+import EditIcon from '@/assets/icons/edit.svg?react';
+import ClosedIcon from '@/assets/icons/archive.svg?react';
+
+interface Props {
+  isClosed: boolean;
+  onToggleIssueState: () => void;
+}
+
+export default function IssueHeaderActions({
+  isClosed,
+  onToggleIssueState,
+}: Props) {
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="small"
+        icon={<EditIcon />}
+        onClick={() => {
+          // TODO 편집로직
+        }}
+      >
+        제목 편집
+      </Button>
+      <Button
+        variant="outline"
+        size="small"
+        icon={<ClosedIcon />}
+        onClick={onToggleIssueState}
+      >
+        {isClosed ? '이슈 열기' : '이슈 닫기'}
+      </Button>
+    </>
+  );
+}

--- a/frontend/src/features/issue/components/detail/IssueHeaderActions.tsx
+++ b/frontend/src/features/issue/components/detail/IssueHeaderActions.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import Button from '@/shared/components/Button';
 import EditIcon from '@/assets/icons/edit.svg?react';
 import CheckIcon from '@/assets/icons/chevronDown.svg?react';
@@ -24,7 +25,7 @@ export default function IssueHeaderActions({
   isSubmitDisabled,
 }: Props) {
   return (
-    <>
+    <ButtonGroup>
       {isEditing ? (
         <>
           <Button
@@ -36,7 +37,7 @@ export default function IssueHeaderActions({
             편집 취소
           </Button>
           <Button
-            variant="outline"
+            variant="contained"
             size="small"
             icon={<CheckIcon />}
             onClick={onEditSubmit}
@@ -65,6 +66,12 @@ export default function IssueHeaderActions({
           </Button>
         </>
       )}
-    </>
+    </ButtonGroup>
   );
 }
+
+const ButtonGroup = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;

--- a/frontend/src/features/issue/components/detail/IssueMeta.tsx
+++ b/frontend/src/features/issue/components/detail/IssueMeta.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { formatCreatedMessage } from '@/features/issue/utils';
+import AlertCircleIcon from '@/assets/icons/alertCircle.svg?react';
+
+interface Props {
+  isClosed: boolean;
+  createdAt: string;
+  authorName: string;
+  commentCount: number;
+}
+
+function IssueMeta({ isClosed, createdAt, authorName, commentCount }: Props) {
+  return (
+    <IssueMetaWrapper>
+      <IsClosedButton isClosed={isClosed}>
+        <AlertCircleIcon />
+        <StateBadge>{isClosed ? '닫힌 이슈' : '열린 이슈'}</StateBadge>
+      </IsClosedButton>
+      <MetaInfo>
+        {formatCreatedMessage({ createdAt, author: authorName, isClosed })}
+      </MetaInfo>
+      <CommentCount>코멘트 {commentCount}개</CommentCount>
+    </IssueMetaWrapper>
+  );
+}
+
+export default React.memo(IssueMeta);
+
+const IssueMetaWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+`;
+
+const MetaInfo = styled.span`
+  color: ${({ theme }) => theme.neutral.text.weak};
+  ${({ theme }) => theme.typography.displayMedium16};
+`;
+
+const CommentCount = styled.span`
+  margin-left: 24px;
+  color: ${({ theme }) => theme.neutral.text.weak};
+  ${({ theme }) => theme.typography.displayMedium16};
+`;
+
+const IsClosedButton = styled.button<{ isClosed: boolean }>`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 8px 16px;
+  background-color: ${({ theme, isClosed }) =>
+    isClosed ? theme.palette.navy : theme.palette.blue};
+
+  border-radius: ${({ theme }) => theme.radius.large};
+  color: ${({ theme }) => theme.brand.text.default};
+
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    opacity: 0.8;
+  }
+`;
+
+const StateBadge = styled.span`
+  padding: 0 4px;
+  color: ${({ theme }) => theme.brand.text.default};
+  ${({ theme }) => theme.typography.displayMedium12};
+`;

--- a/frontend/src/features/issue/hooks/usePatchIssueContent.ts
+++ b/frontend/src/features/issue/hooks/usePatchIssueContent.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { patchIssueContent } from '../api/patchIssueContent';
+import { type PatchIssueContentParams } from '@/features/issue/types/issue';
+
+export function usePatchIssueContent(issueId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (params: PatchIssueContentParams) => patchIssueContent(params),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['issueDetail', issueId] });
+    },
+  });
+}

--- a/frontend/src/features/issue/hooks/usePatchIssueMilestone.ts
+++ b/frontend/src/features/issue/hooks/usePatchIssueMilestone.ts
@@ -5,7 +5,7 @@ export const usePatchIssueMilestone = (issueId: number) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (milestoneId: number) =>
+    mutationFn: (milestoneId: number | null) =>
       patchIssueMilestone(issueId, milestoneId),
     onSuccess: () => {
       queryClient.invalidateQueries({

--- a/frontend/src/features/issue/hooks/usePatchIssueMilestone.ts
+++ b/frontend/src/features/issue/hooks/usePatchIssueMilestone.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { patchIssueMilestone } from '../api/patchIssueMilestone';
+
+export const usePatchIssueMilestone = (issueId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (milestoneId: number) =>
+      patchIssueMilestone(issueId, milestoneId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['issue', issueId, 'milestone'],
+      });
+    },
+  });
+};

--- a/frontend/src/features/issue/hooks/usePatchIssueTitle.ts
+++ b/frontend/src/features/issue/hooks/usePatchIssueTitle.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { patchIssueTitle } from '../api/patchIssueTitle';
+
+export default function usePatchIssueTitle(issueId: number) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (newTitle: string) =>
+      patchIssueTitle({ issueId, title: newTitle }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['issueDetail', issueId] });
+    },
+  });
+}

--- a/frontend/src/features/issue/hooks/usePutIssueAssignees.ts
+++ b/frontend/src/features/issue/hooks/usePutIssueAssignees.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { putIssueAssignees } from '@/features/issue/api/putIssueAssignees';
+
+export const usePutIssueAssignees = (issueId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (assigneeIds: number[]) =>
+      putIssueAssignees(issueId, assigneeIds),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['issue', issueId, 'assignees'],
+      });
+    },
+  });
+};

--- a/frontend/src/features/issue/hooks/usePutIssueLabels.ts
+++ b/frontend/src/features/issue/hooks/usePutIssueLabels.ts
@@ -1,0 +1,13 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { putIssueLabels } from '@/features/issue/api/putIssueLabels';
+
+export const usePutIssueLabels = (issueId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (labelIds: number[]) => putIssueLabels(issueId, labelIds),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['issue', issueId, 'labels'] });
+    },
+  });
+};

--- a/frontend/src/features/issue/types/issue.ts
+++ b/frontend/src/features/issue/types/issue.ts
@@ -54,3 +54,8 @@ export interface Comment {
 export interface CommentsResponse {
   comments: Comment[];
 }
+
+export interface PatchIssueContentParams {
+  issueId: number;
+  content: string;
+}

--- a/frontend/src/features/newIssue/components/IssueCreateSidebar.tsx
+++ b/frontend/src/features/newIssue/components/IssueCreateSidebar.tsx
@@ -1,0 +1,49 @@
+import { type NewIssueState } from '@/features/newIssue/types';
+import { type Dispatch } from '@/features/newIssue/reducers/newIssueFormReducer';
+import IssueSidebar from '@/shared/components/sidebar';
+import { isSameIdArray } from '@/shared/utils/isEqual';
+
+interface IssueCreateSidebarProps {
+  state: NewIssueState;
+  dispatch: Dispatch;
+}
+
+export default function IssueCreateSidebar({
+  state,
+  dispatch,
+}: IssueCreateSidebarProps) {
+  const handleSaveLabel = (incoming: number[]) => {
+    if (isSameIdArray(incoming, state.labels)) return;
+    incoming.forEach(id => {
+      if (!state.labels.includes(id))
+        dispatch({ type: 'TOGGLE_LABEL', payload: id });
+    });
+    state.labels.forEach(id => {
+      if (!incoming.includes(id))
+        dispatch({ type: 'TOGGLE_LABEL', payload: id });
+    });
+  };
+
+  const handleSaveAssignee = (incoming: number[]) => {
+    if (isSameIdArray(incoming, state.assignees)) return;
+    incoming.forEach(id => {
+      if (!state.assignees.includes(id))
+        dispatch({ type: 'TOGGLE_ASSIGNEE', payload: id });
+    });
+    state.assignees.forEach(id => {
+      if (!incoming.includes(id))
+        dispatch({ type: 'TOGGLE_ASSIGNEE', payload: id });
+    });
+  };
+
+  return (
+    <IssueSidebar
+      initialLabelIds={state.labels}
+      onSaveLabel={handleSaveLabel}
+      initialAssigneeIds={state.assignees}
+      onSaveAssignee={handleSaveAssignee}
+      initialMilestoneId={state.milestone}
+      onSaveMilestone={id => dispatch({ type: 'SET_MILESTONE', payload: id })}
+    />
+  );
+}

--- a/frontend/src/features/newIssue/components/NewIssueFormSection.tsx
+++ b/frontend/src/features/newIssue/components/NewIssueFormSection.tsx
@@ -1,54 +1,37 @@
 import styled from '@emotion/styled';
+import { type NewIssueState } from '@/features/newIssue/types';
+import { type Dispatch } from '@/features/newIssue/reducers/newIssueFormReducer';
 import Profile from '@/shared/components/Profile';
 import IssueForm from '@/features/newIssue/components/NewIssueForm';
-import IssueSidebar from '@/shared/components/sidebar';
+import IssueCreateSidebar from '@/features/newIssue/components/IssueCreateSidebar';
 
 interface NewIssueFormSectionProps {
-  title: string;
-  onTitleChange: (value: string) => void;
-
-  content: string;
-  onContentChange: (value: string | ((prev: string) => string)) => void;
-
-  milestoneId: number | null;
-  onMilestoneChange: (id: number) => void;
-
-  selectedLabelIds: number[];
-  onToggleLabel: (id: number) => void;
-
-  selectedAssigneeIds: number[];
-  onToggleAssignee: (id: number) => void;
+  state: NewIssueState;
+  dispatch: Dispatch;
 }
 
 export default function NewIssueFormSection({
-  title,
-  onTitleChange,
-  content,
-  onContentChange,
-  milestoneId,
-  onMilestoneChange,
-  selectedLabelIds,
-  onToggleLabel,
-  selectedAssigneeIds,
-  onToggleAssignee,
+  state,
+  dispatch,
 }: NewIssueFormSectionProps) {
+  const handleTitleChange = (value: string) => {
+    dispatch({ type: 'SET_TITLE', payload: value });
+  };
+
+  const handleContentChange = (value: string | ((prev: string) => string)) => {
+    dispatch({ type: 'SET_CONTENT', payload: value });
+  };
+
   return (
     <MainWrapper>
       <Profile size="md" />
       <IssueForm
-        title={title}
-        content={content}
-        onTitleChange={onTitleChange}
-        onContentChange={onContentChange}
+        title={state.title}
+        content={state.content}
+        onTitleChange={handleTitleChange}
+        onContentChange={handleContentChange}
       />
-      <IssueSidebar
-        selectedAssigneeIds={selectedAssigneeIds}
-        onToggleAssignee={onToggleAssignee}
-        selectedLabelIds={selectedLabelIds}
-        onToggleLabel={onToggleLabel}
-        selectedMilestoneId={milestoneId}
-        onSelectMilestone={onMilestoneChange}
-      />
+      <IssueCreateSidebar state={state} dispatch={dispatch} />
     </MainWrapper>
   );
 }

--- a/frontend/src/features/newIssue/reducers/newIssueFormReducer.ts
+++ b/frontend/src/features/newIssue/reducers/newIssueFormReducer.ts
@@ -9,6 +9,8 @@ export type Action =
   | { type: 'TOGGLE_ASSIGNEE'; payload: number }
   | { type: 'RESET_FORM' };
 
+export type Dispatch = React.Dispatch<Action>;
+
 export function newIssueFormReducer(
   state: NewIssueState,
   action: Action,

--- a/frontend/src/pages/IssueDetailPage.tsx
+++ b/frontend/src/pages/IssueDetailPage.tsx
@@ -76,4 +76,5 @@ const SideSection = styled.div`
   flex-direction: column;
   align-items: flex-end;
   gap: 16px;
+  min-width: 288px;
 `;

--- a/frontend/src/pages/IssueDetailPage.tsx
+++ b/frontend/src/pages/IssueDetailPage.tsx
@@ -1,45 +1,20 @@
 import { useParams } from 'react-router-dom';
 import styled from '@emotion/styled';
-import useIssueAssignees from '@/features/issue/hooks/useIssueAssignees';
-import useIssueLabels from '@/features/issue/hooks/useIssueLabels';
-import useIssueMilestone from '@/features/issue/hooks/useIssueMilestone';
 import useIssueDetail from '@/features/issue/hooks/useIssueDetail';
 import useIssueComments from '@/features/issue/hooks/useIssueComments';
-import usePatchIssueState from '@/features/issue/hooks/usePatchIssueState';
 import { useCurrentUser } from '@/features/auth/hooks/useCurrentUser';
 
 import Divider from '@/shared/components/Divider';
 import IssueHeader from '@/features/issue/components/detail/IssueHeader';
 import IssueMainSection from '@/features/issue/components/detail/IssueMainSection';
-import IssueSidebar from '@/shared/components/sidebar';
 import IssueDeleteButton from '@/features/issue/components/detail/IssueDeleteButton';
 import VerticalStack from '@/layouts/VerticalStack';
+import IssueDetailSidebar from '@/features/issue/components/detail/IssueDetailSidebar';
 
 export default function IssueDetailPage() {
   const { id } = useParams();
   const issueId = Number(id);
   const currentUser = useCurrentUser();
-
-  const { mutate: toggleIssueState, isPending: isToggleLoading } =
-    usePatchIssueState(issueId);
-
-  const {
-    issueLabels,
-    isLoading: isLabelsLoading,
-    isError: isLabelsError,
-  } = useIssueLabels(issueId);
-
-  const {
-    issueAssignees,
-    isLoading: isAssigneesLoading,
-    isError: isAssigneesError,
-  } = useIssueAssignees(issueId);
-
-  const {
-    issueMilestone,
-    isLoading: isMilestoneLoading,
-    isError: isMilestoneError,
-  } = useIssueMilestone(issueId);
 
   const {
     data: issueDetail,
@@ -53,37 +28,16 @@ export default function IssueDetailPage() {
     isError: isCommentError,
   } = useIssueComments(issueId);
 
-  const handleIssueStateToggle = () => {
-    if (!issueDetail || isToggleLoading) return;
-    toggleIssueState({ issueId, targetClosed: !issueDetail.isClosed });
-  };
-
   // TODO 로딩,에러 상태에 따라 분기처리 내부적으로 처리
-  if (
-    isIssueDetailLoading ||
-    isCommentLoading ||
-    isLabelsLoading ||
-    isAssigneesLoading ||
-    isMilestoneLoading
-  ) {
+  if (isIssueDetailLoading || isCommentLoading) {
     return <div>로딩 중...</div>;
   }
 
-  if (
-    isIssueDetailError ||
-    isCommentError ||
-    isLabelsError ||
-    isAssigneesError ||
-    isMilestoneError
-  ) {
+  if (isIssueDetailError || isCommentError) {
     return <div>에러 발생</div>;
   }
 
-  if (!issueDetail || !commentList || !issueAssignees || !issueLabels) return;
-
-  const selectedAssigneeIds = issueAssignees.map(assignee => assignee.id);
-  const selectedLabelIds = issueLabels.map(label => label.id);
-  const selectedMilestoneId = issueMilestone?.id ?? null;
+  if (!issueDetail || !commentList) return;
 
   const isAuthor = currentUser?.nickname === issueDetail.author.nickname;
 
@@ -91,9 +45,8 @@ export default function IssueDetailPage() {
     <VerticalStack>
       <IssueHeader
         {...issueDetail}
-        issueNumber={issueDetail.id}
+        issueId={issueDetail.id}
         commentCount={commentList.length}
-        onToggleIssueState={handleIssueStateToggle}
       />
       <Divider />
       <MainArea>
@@ -104,15 +57,7 @@ export default function IssueDetailPage() {
           author={issueDetail.author}
         />
         <SideSection>
-          {/* TODO 이슈 상세 상태 재설계후 함수 추가 */}
-          <IssueSidebar
-            selectedAssigneeIds={selectedAssigneeIds}
-            onToggleAssignee={() => {}}
-            selectedLabelIds={selectedLabelIds}
-            onToggleLabel={() => {}}
-            selectedMilestoneId={selectedMilestoneId}
-            onSelectMilestone={() => {}}
-          />
+          <IssueDetailSidebar issueId={issueId} />
           {isAuthor && <IssueDeleteButton issueId={issueId} />}
         </SideSection>
       </MainArea>

--- a/frontend/src/pages/NewIssuePage.tsx
+++ b/frontend/src/pages/NewIssuePage.tsx
@@ -28,44 +28,11 @@ export default function NewIssuePage() {
     postNewIssue(payload);
   }
 
-  function handleTitleChange(val: string) {
-    updateIssueForm({ type: 'SET_TITLE', payload: val });
-  }
-
-  function handleContentChange(val: string | ((prev: string) => string)) {
-    updateIssueForm({ type: 'SET_CONTENT', payload: val });
-  }
-  function handleMilestoneChange(id: number) {
-    updateIssueForm({
-      type: 'SET_MILESTONE',
-      payload: issueForm.milestone === id ? null : id,
-    });
-  }
-
-  function handleToggleLabel(id: number) {
-    updateIssueForm({ type: 'TOGGLE_LABEL', payload: id });
-  }
-
-  function handleToggleAssignee(id: number) {
-    updateIssueForm({ type: 'TOGGLE_ASSIGNEE', payload: id });
-  }
-
   return (
     <VerticalStack>
       <NewIssueHeader />
       <Divider />
-      <NewIssueFormSection
-        title={issueForm.title}
-        onTitleChange={handleTitleChange}
-        content={issueForm.content}
-        onContentChange={handleContentChange}
-        milestoneId={issueForm.milestone}
-        onMilestoneChange={handleMilestoneChange}
-        selectedLabelIds={issueForm.labels}
-        onToggleLabel={handleToggleLabel}
-        selectedAssigneeIds={issueForm.assignees}
-        onToggleAssignee={handleToggleAssignee}
-      />
+      <NewIssueFormSection state={issueForm} dispatch={updateIssueForm} />
       <Divider />
       <NewIssueActionButtons
         isSubmitDisabled={isTitleEmpty(issueForm.title)}

--- a/frontend/src/shared/components/Dropdown.tsx
+++ b/frontend/src/shared/components/Dropdown.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 import DropdownIndicator from '@/shared/components/DropdownIndicator';
@@ -6,19 +6,25 @@ import DropdownPortal from '@/shared/components/DropdownPortal';
 
 interface DropdownProps {
   label: string;
+  isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
   children: React.ReactNode;
 }
 
-export default function Dropdown({ label, children }: DropdownProps) {
-  const [open, setOpen] = useState(false);
+export default function Dropdown({
+  label,
+  isOpen,
+  setIsOpen,
+  children,
+}: DropdownProps) {
   const triggerRef = useRef<HTMLButtonElement>(null);
 
   return (
     <Wrapper>
-      <Trigger onClick={() => setOpen(prev => !prev)}>
+      <Trigger onClick={() => setIsOpen(!isOpen)}>
         <DropdownIndicator label={label} ref={triggerRef} />
       </Trigger>
-      {open && (
+      {isOpen && (
         <DropdownPortal anchorRef={triggerRef}>
           <Panel>
             <PanelTitle>{label}</PanelTitle>

--- a/frontend/src/shared/components/TextInput.tsx
+++ b/frontend/src/shared/components/TextInput.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import styled from '@emotion/styled';
+
+interface TextInputProps {
+  label: string;
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  placeholder?: string;
+}
+
+export default function TextInput({
+  label,
+  value,
+  onChange,
+  placeholder,
+}: TextInputProps) {
+  const [isFocused, setIsFocused] = useState(false);
+
+  return (
+    <Wrapper isFocused={isFocused}>
+      <StyledLabel>{label}</StyledLabel>
+      <StyledInput
+        value={value}
+        onChange={onChange}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+        placeholder={placeholder}
+      />
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div<{ isFocused: boolean }>`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-radius: ${({ theme }) => theme.radius.medium};
+  background-color: ${({ isFocused, theme }) =>
+    isFocused ? theme.neutral.surface.strong : theme.neutral.surface.bold};
+
+  box-shadow: ${({ isFocused, theme }) =>
+    isFocused ? `0 0 0 1px ${theme.neutral.border.active}` : 'none'};
+
+  transition:
+    background-color 0.2s,
+    border-color 0.2s;
+`;
+
+const StyledLabel = styled.label`
+  width: 64px;
+  color: ${({ theme }) => theme.neutral.text.weak};
+  ${({ theme }) => theme.typography.displayMedium12};
+`;
+
+const StyledInput = styled.input`
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: ${({ theme }) => theme.neutral.text.strong};
+  ${({ theme }) => theme.typography.displayMedium16};
+
+  &:focus {
+    outline: none;
+  }
+`;

--- a/frontend/src/shared/components/sidebar/AssigneeSection.tsx
+++ b/frontend/src/shared/components/sidebar/AssigneeSection.tsx
@@ -1,38 +1,53 @@
 import styled from '@emotion/styled';
+import { useEffect, useState } from 'react';
 import { useUsers } from '@/features/user/hooks/useUsers';
 import { type User } from '@/features/user/types';
 import Profile from '@/shared/components/Profile';
 import Dropdown from '@/shared/components/Dropdown';
 import DropdownPanel from '@/shared/components/DropdownPanel';
+import { isSameIdArray } from '@/shared/utils/isEqual';
 
 interface AssigneeSectionProps {
-  selectedAssigneeIds: number[];
-  onToggleAssignee: (id: number) => void;
+  initialSelectedIds: number[];
+  onSave: (ids: number[]) => void;
 }
 
 export default function AssigneeSection({
-  selectedAssigneeIds,
-  onToggleAssignee,
+  initialSelectedIds,
+  onSave,
 }: AssigneeSectionProps) {
   const { users } = useUsers();
+  const [selected, setSelected] = useState(initialSelectedIds);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggleAssignee = (id: number) => {
+    setSelected(prev =>
+      prev.includes(id) ? prev.filter(i => i !== id) : [...prev, id],
+    );
+  };
+
+  // 드롭다운이 닫히는 순간에 변경되었으면 저장
+  useEffect(() => {
+    if (!isOpen && !isSameIdArray(selected, initialSelectedIds)) {
+      onSave(selected);
+    }
+  }, [isOpen]);
 
   const assigneeOptions = users.map((user: User) => ({
     id: user.id,
     name: user.nickname,
     imageUrl: user.profileImage,
-    selected: selectedAssigneeIds.includes(user.id),
+    selected: selected.includes(user.id),
   }));
 
-  const selectedAssignees = users.filter(user =>
-    selectedAssigneeIds.includes(user.id),
-  );
+  const selectedAssignees = users.filter(user => selected.includes(user.id));
 
   return (
     <Section>
-      <Dropdown label="담당자">
+      <Dropdown label="담당자" isOpen={isOpen} setIsOpen={setIsOpen}>
         <DropdownPanel<{ imageUrl: string }>
           options={assigneeOptions}
-          onSelect={onToggleAssignee}
+          onSelect={toggleAssignee}
           renderOption={option => (
             <UserInfo>
               <UserImage src={option.imageUrl} />
@@ -41,7 +56,7 @@ export default function AssigneeSection({
           )}
         />
       </Dropdown>
-      {selectedAssigneeIds.length > 0 && (
+      {selected.length > 0 && (
         <SectionList>
           {selectedAssignees.map(assignee => (
             <Profile

--- a/frontend/src/shared/components/sidebar/LabelSection.tsx
+++ b/frontend/src/shared/components/sidebar/LabelSection.tsx
@@ -1,38 +1,53 @@
 import styled from '@emotion/styled';
+import { useEffect, useState } from 'react';
 import { useLabels } from '@/features/label/hooks/useLabels';
 import { type Label } from '@/features/label/types';
 import LabelBadgeList from '@/shared/components/LabelBadgeList';
 import Dropdown from '@/shared/components/Dropdown';
 import DropdownPanel from '@/shared/components/DropdownPanel';
+import { isSameIdArray } from '@/shared/utils/isEqual';
 
 interface LabelSectionProps {
-  selectedLabelIds: number[];
-  onToggleLabel: (id: number) => void;
+  initialSelectedIds: number[];
+  onSave: (ids: number[]) => void;
 }
 
 export default function LabelSection({
-  selectedLabelIds,
-  onToggleLabel,
+  initialSelectedIds,
+  onSave,
 }: LabelSectionProps) {
   const { labels } = useLabels();
+  const [selected, setSelected] = useState(initialSelectedIds);
+  const [isOpen, setIsOpen] = useState(false);
 
-  const LabelOptions = labels.map((label: Label) => ({
+  const toggleLabel = (id: number) => {
+    setSelected(prev =>
+      prev.includes(id) ? prev.filter(i => i !== id) : [...prev, id],
+    );
+  };
+
+  // 닫힐 때만 변경 사항이 있으면 onSave
+  useEffect(() => {
+    if (!isOpen && !isSameIdArray(selected, initialSelectedIds)) {
+      onSave(selected);
+    }
+  }, [isOpen]);
+
+  const labelOptions = labels.map((label: Label) => ({
     id: label.id,
     name: label.name,
     color: label.color,
-    selected: selectedLabelIds.includes(label.id),
+    selected: selected.includes(label.id),
   }));
 
-  const selectedLabels = labels.filter(label =>
-    selectedLabelIds.includes(label.id),
-  );
+  const selectedLabels = labels.filter(label => selected.includes(label.id));
 
   return (
     <Section>
-      <Dropdown label="레이블">
+      <Dropdown label="레이블" isOpen={isOpen} setIsOpen={setIsOpen}>
         <DropdownPanel<{ color: string }>
-          options={LabelOptions}
-          onSelect={onToggleLabel}
+          options={labelOptions}
+          onSelect={toggleLabel}
           renderOption={option => (
             <LabelInfo>
               <ColorDot style={{ backgroundColor: option.color }} />
@@ -41,7 +56,8 @@ export default function LabelSection({
           )}
         />
       </Dropdown>
-      {selectedLabelIds.length > 0 && (
+
+      {selected.length > 0 && (
         <LabelList>
           <LabelBadgeList labels={selectedLabels} />
         </LabelList>
@@ -50,7 +66,7 @@ export default function LabelSection({
   );
 }
 
-const Section = styled.div<{ noDivider?: boolean }>`
+const Section = styled.div`
   width: 100%;
   display: flex;
   flex-direction: column;

--- a/frontend/src/shared/components/sidebar/MilestoneSection.tsx
+++ b/frontend/src/shared/components/sidebar/MilestoneSection.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { useEffect, useState } from 'react';
 import type { MilestoneDetail } from '@/features/milestone/types';
 import useMilestones from '@/features/milestone/hooks/useMilestones';
 import Dropdown from '@/shared/components/Dropdown';
@@ -6,33 +7,47 @@ import DropdownPanel from '@/shared/components/DropdownPanel';
 import MilestoneProgressBar from '@/shared/components/MilestoneProgressBar';
 
 interface MilestoneSectionProps {
-  selectedMilestoneId: number | null;
-  onSelectMilestone: (id: number) => void;
+  initialSelectedId: number | null;
+  onSave: (id: number | null) => void;
 }
 
 export default function MilestoneSection({
-  selectedMilestoneId,
-  onSelectMilestone,
+  initialSelectedId,
+  onSave,
 }: MilestoneSectionProps) {
   const { milestones } = useMilestones();
+  const [selectedId, setSelectedId] = useState<number | null>(
+    initialSelectedId,
+  );
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleSelectMilestone = (id: number) => {
+    setSelectedId(prev => (prev === id ? null : id));
+  };
 
   const milestoneOptions = milestones.map((milestone: MilestoneDetail) => ({
     id: milestone.id,
     name: milestone.title,
     progressRate: milestone.progressRate,
-    selected: selectedMilestoneId === milestone.id,
+    selected: selectedId === milestone.id,
   }));
 
   const selectedMilestone = milestones.find(
-    (milestone: MilestoneDetail) => selectedMilestoneId === milestone.id,
+    (milestone: MilestoneDetail) => selectedId === milestone.id,
   );
+
+  useEffect(() => {
+    if (!isOpen && selectedId !== initialSelectedId) {
+      onSave(selectedId);
+    }
+  }, [isOpen]);
 
   return (
     <Section>
-      <Dropdown label="마엘스톤">
+      <Dropdown label="마일스톤" isOpen={isOpen} setIsOpen={setIsOpen}>
         <DropdownPanel<{ progressRate: number }>
           options={milestoneOptions}
-          onSelect={onSelectMilestone}
+          onSelect={handleSelectMilestone}
           renderOption={option => <span>{option.name}</span>}
         />
       </Dropdown>
@@ -48,7 +63,7 @@ export default function MilestoneSection({
   );
 }
 
-const Section = styled.div<{ noDivider?: boolean }>`
+const Section = styled.div`
   width: 100%;
   display: flex;
   flex-direction: column;

--- a/frontend/src/shared/components/sidebar/index.tsx
+++ b/frontend/src/shared/components/sidebar/index.tsx
@@ -4,39 +4,36 @@ import LabelSection from '@/shared/components/sidebar/LabelSection';
 import MilestoneSection from '@/shared/components/sidebar/MilestoneSection';
 
 interface IssueSidebarProps {
-  selectedAssigneeIds: number[];
-  onToggleAssignee: (id: number) => void;
+  initialAssigneeIds: number[];
+  onSaveAssignee: (ids: number[]) => void;
 
-  selectedLabelIds: number[];
-  onToggleLabel: (id: number) => void;
+  initialLabelIds: number[];
+  onSaveLabel: (ids: number[]) => void;
 
-  selectedMilestoneId: number | null;
-  onSelectMilestone: (id: number) => void;
+  initialMilestoneId: number | null;
+  onSaveMilestone: (id: number | null) => void;
 }
 
 export default function IssueSidebar({
-  selectedAssigneeIds,
-  onToggleAssignee,
-  selectedLabelIds,
-  onToggleLabel,
-  selectedMilestoneId,
-  onSelectMilestone,
+  initialAssigneeIds,
+  onSaveAssignee,
+  initialLabelIds,
+  onSaveLabel,
+  initialMilestoneId,
+  onSaveMilestone,
 }: IssueSidebarProps) {
   return (
     <SidebarWrapper>
       <AssigneeSection
-        selectedAssigneeIds={selectedAssigneeIds}
-        onToggleAssignee={onToggleAssignee}
+        initialSelectedIds={initialAssigneeIds}
+        onSave={onSaveAssignee}
       />
 
-      <LabelSection
-        selectedLabelIds={selectedLabelIds}
-        onToggleLabel={onToggleLabel}
-      />
+      <LabelSection initialSelectedIds={initialLabelIds} onSave={onSaveLabel} />
 
       <MilestoneSection
-        selectedMilestoneId={selectedMilestoneId}
-        onSelectMilestone={onSelectMilestone}
+        initialSelectedId={initialMilestoneId}
+        onSave={onSaveMilestone}
       />
     </SidebarWrapper>
   );

--- a/frontend/src/shared/constants/api.ts
+++ b/frontend/src/shared/constants/api.ts
@@ -14,6 +14,7 @@ export const API = {
 
   ISSUE_STATE: (id: number) => `${API_BASE_URL}/issues/${id}/state`,
   ISSUE_CONTENT: (id: number) => `${API_BASE_URL}/issues/${id}/content`,
+  ISSUE_TITLE: (id: number) => `${API_BASE_URL}/issues/${id}/title`,
 
   LABELS: `${API_BASE_URL}/labels`,
   MILESTONES: `${API_BASE_URL}/milestones`,

--- a/frontend/src/shared/constants/api.ts
+++ b/frontend/src/shared/constants/api.ts
@@ -13,6 +13,7 @@ export const API = {
     `${API_BASE_URL}/issues/${issueId}/comments/${commentId}`,
 
   ISSUE_STATE: (id: number) => `${API_BASE_URL}/issues/${id}/state`,
+  ISSUE_CONTENT: (id: number) => `${API_BASE_URL}/issues/${id}/content`,
 
   LABELS: `${API_BASE_URL}/labels`,
   MILESTONES: `${API_BASE_URL}/milestones`,

--- a/frontend/src/shared/utils/isEqual.ts
+++ b/frontend/src/shared/utils/isEqual.ts
@@ -1,0 +1,18 @@
+/**
+ * 두 ID 배열이 같은 값들로 구성되어 있는지 확인합니다.
+ *
+ * - 요소의 순서는 무시합니다.
+ * - 중복 요소가 없다고 가정합니다.
+ *
+ * @param prevIds 이전 상태의 ID 배열
+ * @param nextIds 새로운 상태의 ID 배열
+ * @returns 두 배열이 같은 ID 목록이면 true, 그렇지 않으면 false
+ */
+export function isSameIdArray(prevIds: number[], nextIds: number[]): boolean {
+  if (prevIds.length !== nextIds.length) return false;
+
+  const sortedPrev = [...prevIds].sort((a, b) => a - b);
+  const sortedNext = [...nextIds].sort((a, b) => a - b);
+
+  return sortedPrev.every((id, index) => id === sortedNext[index]);
+}


### PR DESCRIPTION
## 📌 PR 제목

[Feature] 이슈 메타정보(제목,내용, 라벨, 담당자, 마일스톤) 수정 기능 구현 및 사이드바 리팩토링

## ✅ 작업 요약

이슈 상세 페이지에서 라벨, 담당자, 마일스톤을 드롭다운을 통해 수정할 수 있도록  
메타정보 편집 기능을 구현합니다. 이를 위해 사이드바 구조와 드롭다운 인터랙션 방식을 개선했습니다.

### ✨ 기능 추가

- 이슈 제목(title) 및 설명(content) 편집 기능 구현
- 라벨, 담당자, 마일스톤 수정 기능 구현 (상세 페이지)
- 드롭다운 닫힘 시 변경사항이 있을 경우에만 서버에 patch 요청 전송
- 같은 항목을 다시 클릭하면 선택 해제되도록 토글 처리
- 편집 완료 후 상태 refetch 적용 (항목 변경 시만)

### 🏗️ 구조 및 설계

- `IssueSidebarView`, `ForCreate`, `ForDetail`로 컴포넌트 분리
- 사이드바 내부 훅들을 wrapper로 이동하여 상세 페이지 간결화
- `useState`의 초기값이 반영되지 않는 문제 해결: 로딩 중에는 사이드바 마운트 지연
- 드롭다운의 열림 상태를 각 섹션에서 관리하도록 분리
- 사이드바 prop 정리: `onToggle` → `onSave`, `selected*` → `initial*`
- issue form reducer의 dispatch 타입을 추출하여 명확한 타입 사용 가능하게 리팩토링

### 💄 스타일 개선

- 사이드바 wrapper에 고정 `min-width`를 부여해 레이아웃 리플로우 방지
- `opacity` 트랜지션 적용으로 부드러운 사이드바 등장 처리
- 이슈 헤더에서 제목과 버튼을 줄바꿈/정렬되도록 구조 조정 및 스타일 개선

## ✅ 테스트 확인

- [x] 마일스톤, 라벨, 담당자 모두 정상적으로 편집됨
- [x] 동일 항목 재선택 시 토글 해제 가능
- [x] 드롭다운 닫힘 시에만 서버 요청 발생
- [x] 페이지 로딩 후 사이드바가 자연스럽게 등장함
- [x] 사이드바 영역이 항상 유지되어 레이아웃 흔들림 없음

## 🧠 회고/고민
### 1. 사이드바와 드롭다운 구조 개선

- **문제**: 기존 `IssueSidebar`는 생성용(onToggle) 패턴에 맞춰져 있어, 조회용(onSave)과 충돌 발생
- **논의**:
  - 드롭다운을 누를 때마다 서버에 반영할지
  - 드롭다운이 닫힐 때만 서버에 반영할지
- **선택한 방향**:
  - 드롭다운 열림 상태는 각 섹션이 직접 관리
  - 드롭다운 닫힘 시에만 내부 상태를 `onSaveX`를 통해 전달
  - View 컴포넌트는 `IssueSidebarView`, 로직은 `ForCreate`, `ForDetail`에서 담당

관련 커밋 : 6a19f416f5264b6d462093ac578778361de26b10

### 2. 초기값이 반영되지 않던 문제

- **문제**: `useState(props.initialValue)` 구조에서 props가 나중에 바뀌어도 state는 그대로 유지됨
- **원인**: 컴포넌트가 마운트된 이후에는 `useState`의 초기값이 다시 적용되지 않음
- **해결**: `isLoading` 상태가 `true`일 때는 컴포넌트를 렌더링하지 않고,  
  로딩 완료 이후 마운트되도록 **조건부 렌더링**으로 수정

관련 커밋 : dc08d53dbf867c4dc6c21e60dd076b0ddb3fd657

### 3. 사이드바 등장 시 레이아웃이 깜빡이던 문제

- **원인 1**: 사이드바가 늦게 렌더링되면서 레이아웃 상 공간을 확보하지 못함  
  → `flex: 1`인 코멘트 영역이 전체를 차지했다가 줄어들며 **레이아웃 리플로우** 발생
- **원인 2**: 사이드바가 로딩 완료 후에 **갑자기 나타나 시각적 깜빡임** 발생
- **해결**:
  - `SidebarWrapper`에 고정 `min-width` 설정으로 공간 확보
  - `opacity: 0 → 1` + `transition`으로 **부드러운 페이드인** 처리

관련 커밋 : d452f47e3fe611d1686303cd586c5706de1f7008

#### 참고 영상

https://github.com/user-attachments/assets/d9fbb7af-24e2-4959-aaf6-af1d1d7e5a3b

closes #167 