### PR TITLE
[Feat] 헤더에 유저 프로필 표시 및 토큰 기반 자동 로그아웃 구현

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -1,8 +1,17 @@
+import { useEffect } from 'react';
 import { ThemeProvider as EmotionThemeProvider } from '@/shared/styles/ThemeProvider';
 import { ThemeProvider as ThemeContextProvider } from '@/shared/context/ThemeContext';
+import { setupAutoLogoutByExp } from '@/features/auth/utils/tokens';
 import AppRouter from '@/app/router';
 
 export default function App() {
+  useEffect(() => {
+    const token = localStorage.getItem('access_token');
+    if (token) {
+      setupAutoLogoutByExp(token);
+    }
+  }, []);
+
   return (
     <ThemeContextProvider>
       <EmotionThemeProvider>

--- a/frontend/src/features/auth/utils/tokens.ts
+++ b/frontend/src/features/auth/utils/tokens.ts
@@ -1,14 +1,11 @@
+import { decodeAccessToken } from '@/shared/utils/decodeAccessToken';
+
 export const TOKEN_KEY = 'access_token';
 export const TOKEN_TYPE_KEY = 'token_type';
-export const ISSUED_AT_KEY = 'access_token_issued_at';
-export const TOKEN_LIFETIME = 30 * 60 * 1000; // 30분(ms)
 
 export function setAccessToken(token: string, tokenType: string) {
   localStorage.setItem(TOKEN_KEY, token);
   localStorage.setItem(TOKEN_TYPE_KEY, tokenType);
-  localStorage.setItem(ISSUED_AT_KEY, Date.now().toString());
-
-  setupAutoLogout();
 }
 
 export function getAccessTokenPair(): {
@@ -24,23 +21,28 @@ export function getAccessTokenPair(): {
 export function removeAccessToken() {
   localStorage.removeItem(TOKEN_KEY);
   localStorage.removeItem(TOKEN_TYPE_KEY);
-  localStorage.removeItem(ISSUED_AT_KEY);
 }
 
 export function isAccessTokenStillValid(): boolean {
-  const issuedAt = localStorage.getItem(ISSUED_AT_KEY);
-  if (!issuedAt) return false;
+  const token = localStorage.getItem(TOKEN_KEY);
+  if (!token) return false;
 
-  const elapsed = Date.now() - parseInt(issuedAt, 10);
-  return elapsed < TOKEN_LIFETIME;
+  const decoded = decodeAccessToken(token);
+  if (!decoded || !decoded.exp) return false;
+
+  const now = Date.now();
+  const expirationTime = decoded.exp * 1000;
+  return now < expirationTime;
 }
 
-export function setupAutoLogout() {
-  const issuedAt = localStorage.getItem(ISSUED_AT_KEY);
-  if (!issuedAt) return;
+export function setupAutoLogoutByExp(token: string) {
+  const decoded = decodeAccessToken(token);
+  if (!decoded) return;
 
-  const elapsed = Date.now() - parseInt(issuedAt, 10);
-  const remaining = TOKEN_LIFETIME - elapsed;
+  const { exp } = decoded;
+  const now = Date.now();
+  const expirationTime = exp * 1000;
+  const remaining = expirationTime - now;
 
   if (remaining <= 0) {
     removeAccessToken();

--- a/frontend/src/features/auth/utils/tokens.ts
+++ b/frontend/src/features/auth/utils/tokens.ts
@@ -3,6 +3,10 @@ import { decodeAccessToken } from '@/shared/utils/decodeAccessToken';
 export const TOKEN_KEY = 'access_token';
 export const TOKEN_TYPE_KEY = 'token_type';
 
+const autoLogoutTimerRef: { current: number | null } = {
+  current: null,
+};
+
 export function setAccessToken(token: string, tokenType: string) {
   localStorage.setItem(TOKEN_KEY, token);
   localStorage.setItem(TOKEN_TYPE_KEY, tokenType);
@@ -36,6 +40,11 @@ export function isAccessTokenStillValid(): boolean {
 }
 
 export function setupAutoLogoutByExp(token: string) {
+  // 기존 타이머 제거 (중복 방지)
+  if (autoLogoutTimerRef.current !== null) {
+    clearTimeout(autoLogoutTimerRef.current);
+  }
+
   const decoded = decodeAccessToken(token);
   if (!decoded) return;
 
@@ -48,7 +57,7 @@ export function setupAutoLogoutByExp(token: string) {
     removeAccessToken();
     window.location.href = '/login';
   } else {
-    setTimeout(() => {
+    autoLogoutTimerRef.current = window.setTimeout(() => {
       removeAccessToken();
       window.location.href = '/login';
     }, remaining);

--- a/frontend/src/pages/AuthCallbackPage.tsx
+++ b/frontend/src/pages/AuthCallbackPage.tsx
@@ -1,6 +1,9 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { setAccessToken } from '@/features/auth/utils/tokens';
+import {
+  setAccessToken,
+  setupAutoLogoutByExp,
+} from '@/features/auth/utils/tokens';
 
 export default function AuthCallbackPage() {
   const navigate = useNavigate();
@@ -12,6 +15,7 @@ export default function AuthCallbackPage() {
 
     if (token && tokenType) {
       setAccessToken(token, tokenType);
+      setupAutoLogoutByExp(token);
 
       window.history.replaceState(null, '', '/');
       navigate('/');

--- a/frontend/src/shared/components/Header.tsx
+++ b/frontend/src/shared/components/Header.tsx
@@ -1,10 +1,13 @@
 import styled from '@emotion/styled';
 import { Link } from 'react-router-dom';
+import { useCurrentUser } from '@/features/auth/hooks/useCurrentUser';
 import Profile from '@/shared/components/Profile';
 import Logo from '@/assets/logoMedium.svg?react';
 import DarkModeToggle from '@/shared/components/DarkModeToggle';
 
 export default function Header() {
+  const user = useCurrentUser();
+
   return (
     <Wrapper>
       <LeftSection>
@@ -13,8 +16,7 @@ export default function Header() {
         </Link>
         <DarkModeToggle />
       </LeftSection>
-      {/* 로그인 기능 구현시 유저 정보(이미지,id등) 전달 */}
-      <Profile size="md" />
+      {user && <Profile id={user.nickname} imageUrl={user.profileImageUrl} />}
     </Wrapper>
   );
 }

--- a/frontend/src/shared/components/Profile.tsx
+++ b/frontend/src/shared/components/Profile.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { css, useTheme } from '@emotion/react';
 
 interface ProfileProps {
-  id?: number;
+  id?: number | string;
   size?: 'md' | 'sm';
   name?: string;
   imageUrl?: string;

--- a/frontend/src/test/utils/mockValidAccessToken.ts
+++ b/frontend/src/test/utils/mockValidAccessToken.ts
@@ -1,11 +1,32 @@
-import {
-  TOKEN_KEY,
-  TOKEN_TYPE_KEY,
-  ISSUED_AT_KEY,
-} from '@/features/auth/utils/tokens';
+import { TOKEN_KEY, TOKEN_TYPE_KEY } from '@/features/auth/utils/tokens';
 
-export default function mockValidAccessToken() {
-  localStorage.setItem(TOKEN_KEY, 'mock-token');
+export default function mockValidAccessToken(expOffsetInSeconds = 1800) {
+  const nowInSeconds = Math.floor(Date.now() / 1000);
+
+  const payload = {
+    nickname: 'test-user',
+    profileImageUrl: 'https://example.com/avatar.png',
+    exp: nowInSeconds + expOffsetInSeconds,
+  };
+
+  const token = createMockJwt(payload);
+
+  localStorage.setItem(TOKEN_KEY, token);
   localStorage.setItem(TOKEN_TYPE_KEY, 'Bearer');
-  localStorage.setItem(ISSUED_AT_KEY, Date.now().toString());
+}
+
+// JWT header + payload를 base64로 조합
+function createMockJwt(payload: Record<string, unknown>): string {
+  const header = {
+    alg: 'HS256',
+    typ: 'JWT',
+  };
+
+  const encode = (obj: object) =>
+    btoa(JSON.stringify(obj))
+      .replace(/=/g, '')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_');
+
+  return `${encode(header)}.${encode(payload)}.signature`;
 }


### PR DESCRIPTION
## 🎯 목적

로그인한 유저의 프로필을 헤더에 표시하고, 토큰 만료 시간을 기반으로 자동 로그아웃 기능을 구현합니다.  
또한 `setupAutoLogoutByExp()`가 여러 위치에서 호출되더라도 중복 타이머가 설정되지 않도록 개선하였습니다.



## 🧩 작업 내용

- [x] `Profile` 컴포넌트가 문자열 `id`(nickname)를 받도록 확장
- [x] 유저 프로필 이미지가 헤더에 표시되도록 설정
- [x] 토큰의 `exp` 기반으로 자동 로그아웃 타이머 설정
- [x] 중복 `setTimeout()`을 방지하기 위한 `ref` 객체 사용
- [x] `App.tsx`에서 타이머를 초기화하여 새로고침 후에도 자동 로그아웃 유지



## ✅ 완료 조건

- [x] 로그인 후 헤더에 유저 정보(닉네임, 이미지)가 표시됨
- [x] `exp` 기준으로 정확한 시간에 자동 로그아웃이 동작함
- [x] `AuthCallbackPage`와 `App.tsx` 양쪽에서 `setupAutoLogoutByExp()`가 호출되더라도 타이머는 1개만 유지됨
- [x] 테스트 코드에서 `mockValidAccessToken()`을 통해 유효한 `exp`가 포함된 토큰을 주입하고, 인증 흐름을 시뮬레이션함



## 🧠 주요 고민 및 해결과정

- 처음에는 상태 기반 관리(예: Zustand)를 도입해 로그인 상태를 전역에서 관리하고 `accessToken`의 변화에 따라 자동 로그아웃을 트리거하는 구조를 고려했습니다.
- 하지만 현재 프로젝트는 막바지 단계이고, 새로운 전역 상태 라이브러리 도입은 변경 범위가 커질 수 있어 오히려 리스크가 컸습니다.
- 따라서 최소한의 코드 변경으로 동작 안정성을 확보하는 방향을 택했고, **전역 모듈 레벨 ref 객체를 활용한 중복 방지 구조**로 마무리했습니다.
- 또한 테스트에서는 `mockValidAccessToken()` 유틸을 통해 `exp` 값이 포함된 모의 토큰을 삽입하고, 자동 로그아웃 흐름과 인증 요청이 제대로 작동하는지 확인할 수 있도록 처리했습니다.
- 추후에는 Zustand 등 상태 관리 도구를 도입해 로그인 상태, 사용자 정보 등을 전역에서 관리하고 UI와 인증 로직을 더 명확히 분리할 예정입니다.

  closes #179 