### PR TITLE
[Feature] 레이블 crud 구현

### DIFF
--- a/frontend/src/features/label/api/deleteLabel.ts
+++ b/frontend/src/features/label/api/deleteLabel.ts
@@ -1,0 +1,12 @@
+import { API } from '@/shared/constants/api';
+import fetchWithAuth from '@/shared/utils/fetchWithAuth';
+
+export default async function deleteLabel(id: number): Promise<void> {
+  const res = await fetchWithAuth(`${API.LABELS}/${id}`, {
+    method: 'DELETE',
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to delete label');
+  }
+}

--- a/frontend/src/features/label/api/patchLabel.ts
+++ b/frontend/src/features/label/api/patchLabel.ts
@@ -1,0 +1,45 @@
+import fetchWithAuth from '@/shared/utils/fetchWithAuth';
+
+export interface PatchLabelParams {
+  id: number;
+  name: string;
+  color: string;
+  description?: string;
+}
+
+export async function patchLabel({
+  id,
+  name,
+  color,
+  description,
+}: PatchLabelParams): Promise<void> {
+  const body: Record<string, string> = { name, color };
+  if (description && description.trim()) {
+    body.description = description;
+  }
+
+  const response = await fetchWithAuth(`/api/v1/labels/${id}`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  const statusCodeHandler: Record<number, () => Promise<void>> = {
+    204: () => Promise.resolve(),
+    401: () => {
+      window.location.href = '/login';
+      return Promise.reject(new Error('로그인이 필요합니다'));
+    },
+    404: () => Promise.reject(new Error('요청 경로가 잘못되었습니다')),
+    500: () => Promise.reject(new Error('서버 오류가 발생했습니다')),
+  };
+
+  const defaultHandler = () =>
+    Promise.reject(
+      new Error(`예상치 못한 오류가 발생했습니다 (status: ${response.status})`),
+    );
+
+  return (statusCodeHandler[response.status] ?? defaultHandler)();
+}

--- a/frontend/src/features/label/api/postLabel.ts
+++ b/frontend/src/features/label/api/postLabel.ts
@@ -1,0 +1,39 @@
+import fetchWithAuth from '@/shared/utils/fetchWithAuth';
+
+export interface PostLabelParams {
+  name: string;
+  color: string;
+  description?: string;
+}
+
+export async function postLabel({ name, color, description }: PostLabelParams) {
+  const body: Record<string, string> = { name, color };
+  if (description && description.trim()) {
+    body.description = description;
+  }
+
+  const response = await fetchWithAuth('/api/v1/labels', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  const statusCodeHandler: Record<number, () => Promise<void>> = {
+    201: () => Promise.resolve(), // ✅ JSON 응답 없으니 바로 resolve
+    401: () => {
+      window.location.href = '/login';
+      return Promise.reject(new Error('로그인이 필요합니다'));
+    },
+    404: () => Promise.reject(new Error('요청 경로가 잘못되었습니다')),
+    500: () => Promise.reject(new Error('서버 오류가 발생했습니다')),
+  };
+
+  const defaultHandler = () =>
+    Promise.reject(
+      new Error(`예상치 못한 오류가 발생했습니다 (status: ${response.status})`),
+    );
+
+  return (statusCodeHandler[response.status] ?? defaultHandler)();
+}

--- a/frontend/src/features/label/components/LabelForm.tsx
+++ b/frontend/src/features/label/components/LabelForm.tsx
@@ -1,0 +1,207 @@
+import { useMemo } from 'react';
+import styled from '@emotion/styled';
+import { getAccessibleLabelStyle } from '@/shared/utils/color';
+import { type Label } from '../types';
+import RandomIcon from '@/assets/icons/refreshCcw.svg?react';
+import TextInput from '@/shared/components/TextInput';
+import LabelFormActionButtons from './LabelFormActionButtons';
+import LabelBadge from '@/shared/components/LabelBadge';
+
+interface Props {
+  mode: 'create' | 'edit';
+  formState: {
+    name: string;
+    color: string;
+    description: string;
+  };
+  onChangeFormState: (next: {
+    name: string;
+    color: string;
+    description: string;
+  }) => void;
+  onCancel: () => void;
+  onSubmit: (label: Partial<Label>) => void;
+  isSubmitDisabled: boolean;
+}
+
+export default function LabelForm({
+  mode,
+  formState,
+  onChangeFormState,
+  onCancel,
+  onSubmit,
+  isSubmitDisabled,
+}: Props) {
+  const { name, color, description } = formState;
+
+  const { textColor, borderColor } = useMemo(
+    () => getAccessibleLabelStyle(color),
+    [color],
+  );
+
+  const handleSubmit = () => {
+    if (!name.trim()) return;
+    onSubmit({ name, color, description });
+  };
+
+  const handleRandomColor = () => {
+    const random = `#${Math.floor(Math.random() * 16777215)
+      .toString(16)
+      .padStart(6, '0')}`;
+    onChangeFormState({ ...formState, color: random.toUpperCase() });
+  };
+
+  const handleHexInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value.toUpperCase();
+    if (/^#[0-9A-F]{0,6}$/.test(value)) {
+      onChangeFormState({ ...formState, color: value });
+    }
+  };
+
+  const handleColorPickerChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChangeFormState({ ...formState, color: e.target.value.toUpperCase() });
+  };
+
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    if (value.length <= 15) {
+      onChangeFormState({ ...formState, name: value });
+    }
+  };
+
+  const handleDescriptionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChangeFormState({ ...formState, description: e.target.value });
+  };
+
+  return (
+    <FormWrapper>
+      <PreviewArea>
+        <LabelBadge
+          name={name}
+          color={color}
+          textColor={textColor}
+          borderColor={borderColor}
+        />
+      </PreviewArea>
+
+      <FormContent>
+        <TextInput
+          label="이름"
+          value={name}
+          onChange={handleNameChange}
+          placeholder="레이블의 이름을 입력하세요"
+        />
+
+        <TextInput
+          label="설명(선택)"
+          value={description}
+          onChange={handleDescriptionChange}
+          placeholder="레이블에 대한 설명을 입력하세요"
+        />
+
+        <ColorFieldRow>
+          <ColorLabel>배경 색상</ColorLabel>
+          <ColorInput
+            type="text"
+            value={color.toUpperCase()}
+            onChange={handleHexInputChange}
+          />
+          <ColorPicker
+            type="color"
+            value={/^#[0-9A-F]{6}$/.test(color) ? color : '#e2e2e2'}
+            onChange={handleColorPickerChange}
+          />
+          <RandomButton type="button" onClick={handleRandomColor}>
+            <RandomIcon />
+          </RandomButton>
+        </ColorFieldRow>
+
+        <ButtonGroup>
+          <LabelFormActionButtons
+            mode={mode}
+            onCancel={onCancel}
+            onSubmit={handleSubmit}
+            isSubmitDisabled={isSubmitDisabled}
+          />
+        </ButtonGroup>
+      </FormContent>
+    </FormWrapper>
+  );
+}
+
+const FormWrapper = styled.div`
+  display: flex;
+  gap: 32px;
+  padding: 32px;
+  background-color: ${({ theme }) => theme.neutral.surface.strong};
+  border-radius: ${({ theme }) => theme.radius.medium};
+  border: 1px solid ${({ theme }) => theme.neutral.border.default};
+`;
+
+const PreviewArea = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 6px 12px;
+  border-radius: 4px;
+  width: 288px;
+  font-weight: bold;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  border: 1px solid ${({ theme }) => theme.neutral.border.default};
+`;
+
+const FormContent = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+const ColorFieldRow = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-radius: ${({ theme }) => theme.radius.medium};
+  background-color: ${({ theme }) => theme.neutral.surface.bold};
+`;
+
+const ColorLabel = styled.span`
+  width: 64px;
+  color: ${({ theme }) => theme.neutral.text.weak};
+  ${({ theme }) => theme.typography.displayMedium12};
+`;
+
+const ColorInput = styled.input`
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: ${({ theme }) => theme.neutral.text.strong};
+  ${({ theme }) => theme.typography.displayMedium16};
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+const ColorPicker = styled.input`
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: none;
+  cursor: pointer;
+`;
+
+const RandomButton = styled.button`
+  border: none;
+  background: none;
+  cursor: pointer;
+`;
+
+const ButtonGroup = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;

--- a/frontend/src/features/label/components/LabelFormActionButtons.tsx
+++ b/frontend/src/features/label/components/LabelFormActionButtons.tsx
@@ -1,0 +1,43 @@
+import styled from '@emotion/styled';
+import Button from '@/shared/components/Button';
+import EditIcon from '@/assets/icons/edit.svg?react';
+
+interface LabelFormActionButtonsProps {
+  mode: 'create' | 'edit';
+  onCancel: () => void;
+  onSubmit: () => void;
+  isSubmitDisabled: boolean;
+}
+
+export default function LabelFormActionButtons({
+  mode,
+  onCancel,
+  onSubmit,
+  isSubmitDisabled,
+}: LabelFormActionButtonsProps) {
+  const cancelText = mode === 'create' ? '생성 취소' : '편집 취소';
+  const submitText = mode === 'create' ? '생성 완료' : '편집 완료';
+
+  return (
+    <ButtonGroupWrapper>
+      <Button variant="outline" size="small" onClick={onCancel}>
+        {cancelText}
+      </Button>
+      <Button
+        size="small"
+        icon={<EditIcon />}
+        disabled={isSubmitDisabled}
+        onClick={onSubmit}
+      >
+        {submitText}
+      </Button>
+    </ButtonGroupWrapper>
+  );
+}
+
+const ButtonGroupWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 16px;
+  margin-top: 12px;
+`;

--- a/frontend/src/features/label/hooks/useCreateLabel.ts
+++ b/frontend/src/features/label/hooks/useCreateLabel.ts
@@ -1,0 +1,10 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { postLabel, type PostLabelParams } from '../api/postLabel';
+
+export function useCreateLabel() {
+  // const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (params: PostLabelParams) => postLabel(params),
+  });
+}

--- a/frontend/src/features/label/hooks/useDeleteLabel.ts
+++ b/frontend/src/features/label/hooks/useDeleteLabel.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@tanstack/react-query';
+import deleteLabel from '@/features/label/api/deleteLabel';
+
+export function useDeleteLabel() {
+  return useMutation({
+    mutationFn: (id: number) => deleteLabel(id),
+  });
+}

--- a/frontend/src/features/label/hooks/useLabels.ts
+++ b/frontend/src/features/label/hooks/useLabels.ts
@@ -7,7 +7,7 @@ export function useLabels() {
     useQuery<GetLabelsResponse>({
       queryKey: ['labels'],
       queryFn: getLabels,
-      placeholderData: keepPreviousData,
+      // placeholderData: keepPreviousData,
     });
 
   return {

--- a/frontend/src/features/label/hooks/usePatchLabel.ts
+++ b/frontend/src/features/label/hooks/usePatchLabel.ts
@@ -1,0 +1,13 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { patchLabel, type PatchLabelParams } from '../api/patchLabel';
+
+export function usePatchLabel() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (params: PatchLabelParams) => patchLabel(params),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['labels'] });
+    },
+  });
+}

--- a/frontend/src/pages/LabelsPage.tsx
+++ b/frontend/src/pages/LabelsPage.tsx
@@ -1,25 +1,111 @@
 import { useState } from 'react';
 import styled from '@emotion/styled';
 import { useLabels } from '@/features/label/hooks/useLabels';
+import { useCreateLabel } from '@/features/label/hooks/useCreateLabel';
+import { usePatchLabel } from '@/features/label/hooks/usePatchLabel';
 import VerticalStack from '@/layouts/VerticalStack';
 import LabelMilestoneTab from '@/shared/components/LabelMilestoneTab';
 import AddLabelButton from '@/features/label/components/AddLabelButton';
 import LabelListContainer from '@/features/label/components/LabelListContainer';
+import LabelForm from '@/features/label/components/LabelForm';
+import { type Label } from '@/features/label/types';
+import { useDeleteLabel } from '@/features/label/hooks/useDeleteLabel';
 
 export default function LabelsPage() {
   const { labels, isFetching, isError, refetch } = useLabels();
-  //TODO 생성 및 편집 모드 구현
+  const { mutateAsync: createLabel } = useCreateLabel();
+  const { mutateAsync: updateLabel } = usePatchLabel();
+  const { mutateAsync: deleteLabel } = useDeleteLabel();
   const [isCreating, setIsCreating] = useState(false);
   const [editId, setEditId] = useState<number | null>(null);
+  const [formState, setFormState] = useState({
+    name: 'label',
+    color: '#6E6E6E',
+    description: '',
+  });
 
-  const handleEdit = (id: number) => {
+  const isCreateSubmitDisabled =
+    !formState.name.trim() || !formState.color.trim();
+
+  const targetLabel = labels.find(l => l.id === editId);
+
+  const isEditSubmitDisabled = targetLabel
+    ? targetLabel.name === formState.name &&
+      targetLabel.color === formState.color &&
+      (targetLabel.description || '') === (formState.description || '')
+    : true;
+
+  const resetFormState = () => {
+    setFormState({
+      name: 'label',
+      color: '#6E6E6E',
+      description: '',
+    });
+  };
+
+  const handleStartCreate = () => {
+    setIsCreating(true);
+    setEditId(null);
+  };
+
+  const handleStartEdit = (id: number) => {
     setEditId(id);
-    setIsCreating(false); // 편집 모드 진입 시 생성모드는 닫힘
+    setIsCreating(false);
+  };
+
+  const handleCancelForm = () => {
+    setIsCreating(false);
+    setEditId(null);
+  };
+
+  const handleCreateSubmit = async (label: Partial<Label>) => {
+    const { name, color, description } = label;
+
+    const payload: {
+      name: string;
+      color: string;
+      description?: string;
+    } = {
+      name: name!,
+      color: color!,
+    };
+
+    if (description && description.trim()) {
+      payload.description = description;
+    }
+
+    await createLabel(payload);
+    await refetch();
+    resetFormState();
+    setIsCreating(false);
+  };
+
+  const handleEditSubmit = async (label: Partial<Label>) => {
+    if (editId === null) return;
+
+    const payload: {
+      id: number;
+      name: string;
+      color: string;
+      description?: string;
+    } = {
+      id: editId,
+      name: label.name!,
+      color: label.color!,
+    };
+
+    if (label.description && label.description.trim()) {
+      payload.description = label.description;
+    }
+
+    await updateLabel(payload);
+    await refetch();
+    resetFormState();
+    setEditId(null);
   };
 
   const handleDelete = async (id: number) => {
-    // TODO: deleteLabel API 호출
-    console.log('Deleting label id:', id);
+    await deleteLabel(id);
     await refetch();
   };
 
@@ -27,19 +113,35 @@ export default function LabelsPage() {
     <VerticalStack>
       <PageHeader>
         <LabelMilestoneTab labelCount={labels.length} milestoneCount={5} />
-        <AddLabelButton
-          onClick={() => {
-            setIsCreating(true);
-            setEditId(null);
-          }}
-        />
+        <AddLabelButton onClick={handleStartCreate} />
       </PageHeader>
 
+      {isCreating && (
+        <LabelForm
+          mode="create"
+          formState={formState}
+          onChangeFormState={setFormState}
+          onCancel={handleCancelForm}
+          onSubmit={handleCreateSubmit}
+          isSubmitDisabled={isCreateSubmitDisabled}
+        />
+      )}
+
+      {editId !== null && (
+        <LabelForm
+          mode="edit"
+          formState={formState}
+          onChangeFormState={setFormState}
+          onCancel={handleCancelForm}
+          onSubmit={handleEditSubmit}
+          isSubmitDisabled={isEditSubmitDisabled}
+        />
+      )}
       <LabelListContainer
         labels={labels}
         isFetching={isFetching}
         isError={isError}
-        onEdit={handleEdit}
+        onEdit={handleStartEdit}
         onDelete={handleDelete}
       />
     </VerticalStack>


### PR DESCRIPTION
added create, read, update, and delete functionalities for labels using react-query hooks and updated the UI to reflect changes

## 📌 PR 제목

[//]: # (<!-- 예: [Feature] HttpParser - 요청 라인 파싱 기능 추가 -->)

## ✅ 작업 요약

[//]: # (<!-- 어떤 목적을 가지고 무엇을 구현/수정했는지 요약 -->)

[//]: # (- 요청 라인 파싱 기능 구현)

[//]: # (- 잘못된 HTTP 버전 예외 처리 추가)

[//]: # (- 간단한 테스트 작성 및 통과 확인)

## ✅ 테스트 확인

[//]: # (- [ ]  GTest 기반 테스트 작성 완료)

[//]: # (- [ ]  테스트 전부 통과)

[//]: # (- [ ]  CI 정상 동작 확인)

## 🧠 회고/고민

[//]: # (<!-- 기능을 구현하면서 고민했던 점, 느낀 점 -->)

[//]: # ()
[//]: # (- split 함수 위치를 util로 뺄지 파서 내부에 둘지 고민했음)

[//]: # (- HttpVersion 검증 방식은 enum을 써야 할까?)

## 🔗 참고 자료

[//]: # (- [RFC 7230 Section 3.1.1]&#40;https://datatracker.ietf.org/doc/html/rfc7230#section-3.1.1&#41;)
